### PR TITLE
Add support for 2D queries

### DIFF
--- a/examples/coolerpp_dump_example.cpp
+++ b/examples/coolerpp_dump_example.cpp
@@ -78,9 +78,11 @@ int main(int argc, char** argv) {
     if (argc == 2) {
       nnz = dump(cooler);
     } else if (argc == 3) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       nnz = dump(cooler, argv[2]);
     } else {
       assert(argc == 4);
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
       nnz = dump(cooler, argv[2], argv[3]);
     }
 

--- a/examples/coolerpp_dump_example.cpp
+++ b/examples/coolerpp_dump_example.cpp
@@ -15,17 +15,48 @@
 
 using namespace coolerpp;
 
-template <class N>
-void print_pixel(const Pixel<N>& pixel) {
-  fmt::print(FMT_COMPILE("{:bedpe}\t{}\n"), pixel.coords, pixel.count);
+struct Coords {
+  std::string chrom{};
+  std::uint32_t start{};
+  std::uint32_t end{};
+};
+
+template <typename It>
+static std::size_t print_pixels(It first_pixel, It last_pixel) {
+  std::size_t nnz = 0;
+  std::for_each(first_pixel, last_pixel, [&](const auto& pixel) {
+    ++nnz;
+    fmt::print(FMT_COMPILE("{:bedpe}\t{}\n"), pixel.coords, pixel.count);
+  });
+
+  return nnz;
+}
+
+static std::size_t dump(const File& cooler) {
+  if (cooler.has_integral_pixels()) {
+    return print_pixels(cooler.begin<std::int64_t>(), cooler.end<std::int64_t>());
+  }
+  return print_pixels(cooler.begin<double>(), cooler.end<double>());
+}
+
+static std::size_t dump(const File& cooler, const std::string& coords) {
+  if (cooler.has_integral_pixels()) {
+    auto selector = cooler.fetch<std::int64_t>(coords);
+    return print_pixels(selector.begin(), selector.end());
+  }
+
+  auto selector = cooler.fetch<double>(coords);
+  return print_pixels(selector.begin(), selector.end());
 }
 
 int main(int argc, char** argv) {
-  if (argc != 2) {
+  if (argc < 2) {
     fmt::print(stderr,
-               FMT_STRING("Usage:   {0} my_cooler.cool\n"
+               FMT_STRING("Usage:   {0} my_cooler.cool [region]\n"
                           "Example: {0} my_cooler.cool\n"
-                          "Example: {0} my_cooler.mcool::/resolutions/10000\n"),
+                          "Example: {0} my_cooler.mcool::/resolutions/10000\n"
+                          "Example: {0} my_cooler.cool chr1\n"
+                          "Example: {0} my_cooler.cool chr1:50000-100000\n"),
                argv[0]);  // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     return 1;
   }
@@ -36,14 +67,12 @@ int main(int argc, char** argv) {
   try {
     const auto t0 = std::chrono::steady_clock::now();
     const auto cooler = File::open_read_only(path_to_cooler);
+    std::size_t nnz = 0;
 
-    if (cooler.has_integral_pixels()) {
-      using T = std::int64_t;
-      std::for_each(cooler.begin<T>(), cooler.end<T>(), print_pixel<T>);
-
+    if (argc == 2) {
+      nnz = dump(cooler);
     } else {
-      using T = double;
-      std::for_each(cooler.begin<T>(), cooler.end<T>(), print_pixel<T>);
+      nnz = dump(cooler, argv[2]);
     }
 
     const auto t1 = std::chrono::steady_clock::now();
@@ -51,12 +80,12 @@ int main(int argc, char** argv) {
     const auto elapsed_time_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
 
-    fmt::print(stderr, FMT_STRING("Dumped {} pixels in {}s!\n"), *cooler.attributes().nnz,
+    fmt::print(stderr, FMT_STRING("Dumped {} pixels in {}s!\n"), nnz,
                static_cast<double>(elapsed_time_ms) / 1000.0);
   } catch (const std::exception& e) {
     fmt::print(
         stderr,
-        FMT_STRING("The following error occurred while running coolerpp_dump on file {}: \"{}\"\n"),
+        FMT_STRING("The following error occurred while running coolerpp_dump on file {}: {}\n"),
         path_to_cooler, e.what());
     return 1;
   }

--- a/examples/coolerpp_load_example.cpp
+++ b/examples/coolerpp_load_example.cpp
@@ -55,7 +55,7 @@ void parse_bedpe_record(std::string_view line, std::array<std::string, 7>& buff,
   }
 }
 
-[[nodiscard]] Pixel<std::uint32_t> construct_pixel(std::shared_ptr<const BinTableLazy> bins,
+[[nodiscard]] Pixel<std::uint32_t> construct_pixel(const std::shared_ptr<const BinTableLazy>& bins,
                                                    const std::array<std::string, 7>& bedpe_tokens) {
   const auto& chrom1_name = bedpe_tokens[0];
   const auto& chrom2_name = bedpe_tokens[3];

--- a/examples/coolerpp_load_example.cpp
+++ b/examples/coolerpp_load_example.cpp
@@ -55,7 +55,7 @@ void parse_bedpe_record(std::string_view line, std::array<std::string, 7>& buff,
   }
 }
 
-[[nodiscard]] Pixel<std::uint32_t> construct_pixel(const BinTableLazy& bins,
+[[nodiscard]] Pixel<std::uint32_t> construct_pixel(std::shared_ptr<const BinTableLazy> bins,
                                                    const std::array<std::string, 7>& bedpe_tokens) {
   const auto& chrom1_name = bedpe_tokens[0];
   const auto& chrom2_name = bedpe_tokens[3];
@@ -73,7 +73,7 @@ void ingest_pixels(const std::string& path_to_chrom_sizes, const std::string& pa
                    std::uint32_t bin_size, std::size_t batch_size = 100'000) {
   auto chromosomes = import_chromosomes(path_to_chrom_sizes);
   auto cooler = File::create_new_cooler<ContactT>(path_to_output_cooler, chromosomes, bin_size);
-  const auto& bins = cooler.bins();
+  const auto& bins = cooler.bins_ptr();
 
   std::vector<Pixel<ContactT>> write_buffer;
   write_buffer.reserve(batch_size);

--- a/src/bin_table_impl.hpp
+++ b/src/bin_table_impl.hpp
@@ -10,10 +10,9 @@
 
 namespace coolerpp {  // NOLINT
 
-constexpr Bin::Bin(const Chromosome &chrom_, std::uint32_t bin_start_,
-                   std::uint32_t bin_end_) noexcept
-    : chrom(chrom_), bin_start(bin_start_), bin_end(bin_end_) {
-  assert(bin_start <= bin_end);
+constexpr Bin::Bin(const Chromosome &chrom_, std::uint32_t start_, std::uint32_t end_) noexcept
+    : chrom(chrom_), start(start_), end(end_) {
+  assert(start <= end);
 }
 
 template <class ChromIt>
@@ -84,5 +83,5 @@ constexpr auto fmt::formatter<coolerpp::Bin>::parse(format_parse_context &ctx)
 template <class FormatContext>
 inline auto fmt::formatter<coolerpp::Bin>::format(const coolerpp::Bin &b, FormatContext &ctx) const
     -> decltype(ctx.out()) {
-  return fmt::format_to(ctx.out(), FMT_STRING("{}:{}-{}"), b.chrom.name, b.bin_start, b.bin_end);
+  return fmt::format_to(ctx.out(), FMT_STRING("{}:{}-{}"), b.chrom.name, b.start, b.end);
 }

--- a/src/coolerpp.cpp
+++ b/src/coolerpp.cpp
@@ -518,12 +518,12 @@ void File::validate_bins() const {
             fmt::format(FMT_STRING("Expected {} bins, found {}"), this->bins().size(), i));
       }
 
-      if (this->chromosomes().at(*chrom_it).name != bin.chrom.name || *start_it != bin.bin_start ||
-          *end_it != bin.bin_end) {
+      if (this->chromosomes().at(*chrom_it).name != bin.chrom.name || *start_it != bin.start ||
+          *end_it != bin.end) {
         throw std::runtime_error(
             fmt::format(FMT_STRING("Bin #{}: expected {}:{}-{}, found {}:{}-{}"), i,
                         this->chromosomes().at(*chrom_it).name, *start_it, *end_it, bin.chrom.name,
-                        bin.bin_start, bin.bin_end));
+                        bin.start, bin.end));
       }
       ++chrom_it;
       ++start_it;
@@ -681,10 +681,10 @@ void File::write_bin_table(Dataset &chrom_dset, Dataset &start_dset, Dataset &en
                    [&](const Bin &bin) { return bin_table.chromosomes().get_id(bin.chrom); });
 
   start_dset.write(bin_table.begin(), bin_table.end(), 0, true,
-                   [&](const Bin &bin) { return bin.bin_start; });
+                   [&](const Bin &bin) { return bin.start; });
 
   end_dset.write(bin_table.begin(), bin_table.end(), 0, true,
-                 [&](const Bin &bin) { return bin.bin_end; });
+                 [&](const Bin &bin) { return bin.end; });
 
   assert(chrom_dset.size() == bin_table.size());
   assert(start_dset.size() == bin_table.size());

--- a/src/coolerpp.cpp
+++ b/src/coolerpp.cpp
@@ -64,12 +64,12 @@ File::File(std::string_view uri, unsigned mode, bool validate)
       _datasets(open_datasets(_root_group)),
       _attrs(read_standard_attributes(_root_group)),
       _pixel_variant(detect_pixel_type(_root_group)),
-      _bins(std::make_unique<BinTable>(
+      _bins(std::make_shared<BinTable>(
           import_chroms(_datasets.at("chroms/name"), _datasets.at("chroms/length"), false),
           this->bin_size())),
-      _index(std::make_unique<Index>(import_indexes(_datasets.at("indexes/chrom_offset"),
+      _index(std::make_shared<Index>(import_indexes(_datasets.at("indexes/chrom_offset"),
                                                     _datasets.at("indexes/bin1_offset"),
-                                                    chromosomes(), *_bins, *_attrs.nnz, false))) {
+                                                    chromosomes(), _bins, *_attrs.nnz, false))) {
   assert(mode == HighFive::File::ReadOnly || mode == HighFive::File::ReadWrite);
   if (validate) {
     this->validate_bins();
@@ -129,6 +129,8 @@ auto File::bins() const noexcept -> const BinTable & {
   assert(this->_bins);
   return *this->_bins;
 }
+
+auto File::bins_ptr() const noexcept -> std::shared_ptr<const BinTable> { return this->_bins; }
 
 internal::NumericVariant File::detect_pixel_type(const RootGroup &root_grp, std::string_view path) {
   [[maybe_unused]] HighFive::SilenceHDF5 silencer{};
@@ -435,8 +437,10 @@ auto File::import_chroms(const Dataset &chrom_names, const Dataset &chrom_sizes,
 }
 
 Index File::import_indexes(const Dataset &chrom_offset_dset, const Dataset &bin_offset_dset,
-                           const ChromosomeSet &chroms, const BinTableLazy &bin_table,
+                           const ChromosomeSet &chroms,
+                           std::shared_ptr<const BinTableLazy> bin_table,
                            std::uint64_t expected_nnz, bool missing_ok) {
+  assert(bin_table);
   try {
     if (bin_offset_dset.empty()) {
       assert(chrom_offset_dset.empty());
@@ -446,10 +450,10 @@ Index File::import_indexes(const Dataset &chrom_offset_dset, const Dataset &bin_
       throw std::runtime_error("index datasets are empty");
     }
 
-    if (bin_offset_dset.size() != bin_table.size() + 1) {
+    if (bin_offset_dset.size() != bin_table->size() + 1) {
       throw std::runtime_error(
           fmt::format(FMT_STRING("failed to import offsets from {}: expected {} offsets, found {}"),
-                      bin_offset_dset.hdf5_path(), bin_table.size() + 1, bin_offset_dset.size()));
+                      bin_offset_dset.hdf5_path(), bin_table->size() + 1, bin_offset_dset.size()));
     }
 
     const auto chrom_offsets = import_chrom_offsets(chrom_offset_dset, chroms.size() + 1);
@@ -459,11 +463,11 @@ Index File::import_indexes(const Dataset &chrom_offset_dset, const Dataset &bin_
     std::size_t bin_id = 0;
     std::for_each(bin_offset_dset.begin<std::uint64_t>(), bin_offset_dset.end<std::uint64_t>(),
                   [&](std::uint64_t offset) {
-                    if (bin_id < bin_table.size()) {
+                    if (bin_id < bin_table->size()) {
                       idx.set_offset_by_bin_id(bin_id++, offset);
                     } else {
                       // Last bin
-                      assert(bin_id == bin_table.size());
+                      assert(bin_id == bin_table->size());
                     }
                   });
 

--- a/src/coolerpp_impl.hpp
+++ b/src/coolerpp_impl.hpp
@@ -445,6 +445,12 @@ inline PixelSelector<N> File::fetch(std::string_view query) const {
 }
 
 template <class N>
+inline PixelSelector<N> File::fetch(std::string_view chrom, std::uint32_t start,
+                                    std::uint32_t end) const {
+  return this->fetch<N>(PixelCoordinates{this->_bins, chrom, start, end - std::min(1U, end)});
+}
+
+template <class N>
 inline PixelSelector<N> File::fetch(PixelCoordinates query) const {
   // clang-format off
   return PixelSelector<N>(this->_index,
@@ -456,14 +462,37 @@ inline PixelSelector<N> File::fetch(PixelCoordinates query) const {
 }
 
 template <class N>
-inline PixelSelector<N> File::fetch(std::string_view chrom1_name, std::uint32_t pos1,
-                                    std::string_view chrom2_name, std::uint32_t pos2) const {
+inline PixelSelector<N> File::fetch(std::string_view range1, std::string_view range2) const {
+  if (range1 == range2) {
+    return this->fetch<N>(range1);
+  }
+
+  return this->fetch<N>(PixelSelector<N>::parse_query(this->_bins, range1),
+                        PixelSelector<N>::parse_query(this->_bins, range2));
+}
+
+template <class N>
+inline PixelSelector<N> File::fetch(std::string_view chrom1, std::uint32_t start1,
+                                    std::uint32_t end1, std::string_view chrom2,
+                                    std::uint32_t start2, std::uint32_t end2) const {
   // clang-format off
   return PixelSelector<N>(this->_index,
                           this->dataset("pixels/bin1_id"),
                           this->dataset("pixels/bin2_id"),
                           this->dataset("pixels/count"),
-                          PixelCoordinates{this->_bins, chrom1_name, chrom2_name, pos1, pos2});
+                          PixelCoordinates{this->_bins, chrom1, start1, end1},
+                          PixelCoordinates{this->_bins, chrom2, start2, end2});
+  // clang-format on
+}
+
+template <class N>
+inline PixelSelector<N> File::fetch(PixelCoordinates coord1, PixelCoordinates coord2) const {
+  // clang-format off
+  return PixelSelector<N>(this->_index,
+                          this->dataset("pixels/bin1_id"),
+                          this->dataset("pixels/bin2_id"),
+                          this->dataset("pixels/count"),
+                          std::move(coord1), std::move(coord2));
   // clang-format on
 }
 

--- a/src/dataset_impl.hpp
+++ b/src/dataset_impl.hpp
@@ -296,10 +296,8 @@ inline Dataset::iterator<T>::iterator(const Dataset &dset, std::size_t h5_offset
 
 template <class T>
 constexpr bool Dataset::iterator<T>::operator==(const iterator &other) const noexcept {
-  // clang-format off
-  return this->_dset == other._dset &&
-         this->_h5_offset == other._h5_offset;
-  // clang-format on
+  assert(this->_dset == other._dset);
+  return this->_h5_offset == other._h5_offset;
 }
 template <class T>
 constexpr bool Dataset::iterator<T>::operator!=(const iterator &other) const noexcept {
@@ -308,32 +306,24 @@ constexpr bool Dataset::iterator<T>::operator!=(const iterator &other) const noe
 
 template <class T>
 constexpr bool Dataset::iterator<T>::operator<(const iterator &other) const noexcept {
-  // clang-format off
-  return this->_dset <= other._dset &&
-         this->_h5_offset < other._h5_offset;
-  // clang-format on
+  assert(this->_dset == other._dset);
+  return this->_h5_offset < other._h5_offset;
 }
 template <class T>
 constexpr bool Dataset::iterator<T>::operator<=(const iterator &other) const noexcept {
-  // clang-format off
-  return this->_dset <= other._dset &&
-         this->_h5_offset <= other._h5_offset;
-  // clang-format on
+  assert(this->_dset == other._dset);
+  return this->_h5_offset <= other._h5_offset;
 }
 
 template <class T>
 constexpr bool Dataset::iterator<T>::operator>(const iterator &other) const noexcept {
-  // clang-format off
-  return this->_dset >= other._dset &&
-         this->_h5_offset > other._h5_offset;
-  // clang-format on
+  assert(this->_dset == other._dset);
+  return this->_h5_offset > other._h5_offset;
 }
 template <class T>
 constexpr bool Dataset::iterator<T>::operator>=(const iterator &other) const noexcept {
-  // clang-format off
-  return this->_dset >= other._dset &&
-         this->_h5_offset >= other._h5_offset;
-  // clang-format on
+  assert(this->_dset == other._dset);
+  return this->_h5_offset >= other._h5_offset;
 }
 
 template <class T>
@@ -451,6 +441,11 @@ constexpr std::uint64_t Dataset::iterator<T>::h5_offset() const noexcept {
 template <class T>
 constexpr std::size_t Dataset::iterator<T>::underlying_buff_capacity() const noexcept {
   return this->_buff_capacity;
+}
+
+template <class T>
+constexpr const Dataset &Dataset::iterator<T>::dataset() const noexcept {
+  return *this->_dset;
 }
 
 template <class T>

--- a/src/include/coolerpp/bin_table.hpp
+++ b/src/include/coolerpp/bin_table.hpp
@@ -23,8 +23,7 @@ struct Bin {
   std::uint32_t end;
 
   Bin() = delete;
-  constexpr Bin(const Chromosome &chrom_, std::uint32_t start_,
-                std::uint32_t end_) noexcept;
+  constexpr Bin(const Chromosome &chrom_, std::uint32_t start_, std::uint32_t end_) noexcept;
   [[nodiscard]] bool operator==(const Bin &other) const noexcept;
   [[nodiscard]] bool operator!=(const Bin &other) const noexcept;
 

--- a/src/include/coolerpp/bin_table.hpp
+++ b/src/include/coolerpp/bin_table.hpp
@@ -19,12 +19,12 @@ namespace coolerpp {
 
 struct Bin {
   const Chromosome &chrom;
-  std::uint32_t bin_start;
-  std::uint32_t bin_end;
+  std::uint32_t start;
+  std::uint32_t end;
 
   Bin() = delete;
-  constexpr Bin(const Chromosome &chrom_, std::uint32_t bin_start_,
-                std::uint32_t bin_end_) noexcept;
+  constexpr Bin(const Chromosome &chrom_, std::uint32_t start_,
+                std::uint32_t end_) noexcept;
   [[nodiscard]] bool operator==(const Bin &other) const noexcept;
   [[nodiscard]] bool operator!=(const Bin &other) const noexcept;
 

--- a/src/include/coolerpp/coolerpp.hpp
+++ b/src/include/coolerpp/coolerpp.hpp
@@ -192,10 +192,17 @@ class File {
   template <class N>
   [[nodiscard]] PixelSelector<N> fetch(std::string_view query) const;
   template <class N>
-  [[nodiscard]] PixelSelector<N> fetch(PixelCoordinates query) const;
+  [[nodiscard]] PixelSelector<N> fetch(std::string_view chrom, std::uint32_t start,
+                                       std::uint32_t end) const;
   template <class N>
-  [[nodiscard]] PixelSelector<N> fetch(std::string_view chrom1_name, std::uint32_t pos1,
-                                       std::string_view chrom2_name, std::uint32_t pos2) const;
+  [[nodiscard]] PixelSelector<N> fetch(PixelCoordinates query) const;
+
+  template <class N>
+  [[nodiscard]] PixelSelector<N> fetch(std::string_view range1, std::string_view range2) const;
+  template <class N>
+  [[nodiscard]] PixelSelector<N> fetch(std::string_view chrom1, std::uint32_t start1,
+                                       std::uint32_t end1, std::string_view chrom2,
+                                       std::uint32_t start2, std::uint32_t end2) const;
   template <class N>
   [[nodiscard]] PixelSelector<N> fetch(PixelCoordinates coord1, PixelCoordinates coord2) const;
 

--- a/src/include/coolerpp/coolerpp.hpp
+++ b/src/include/coolerpp/coolerpp.hpp
@@ -191,6 +191,8 @@ class File {
   template <class N>
   [[nodiscard]] PixelSelector<N> fetch(std::string_view query) const;
   template <class N>
+  [[nodiscard]] PixelSelector<N> fetch(PixelCoordinates query) const;
+  template <class N>
   [[nodiscard]] PixelSelector<N> fetch(std::string_view chrom1_name, std::uint32_t pos1,
                                        std::string_view chrom2_name, std::uint32_t pos2) const;
 

--- a/src/include/coolerpp/coolerpp.hpp
+++ b/src/include/coolerpp/coolerpp.hpp
@@ -97,8 +97,8 @@ class File {
   DatasetMap _datasets{};
   StandardAttributes _attrs{};
   internal::NumericVariant _pixel_variant{};
-  std::unique_ptr<BinTable> _bins{};
-  std::unique_ptr<Index> _index{};
+  std::shared_ptr<const BinTable> _bins{};
+  std::shared_ptr<Index> _index{};
   bool _finalize{false};
 
   // Constructors are private. Cooler files are opened using factory methods
@@ -158,6 +158,7 @@ class File {
   [[nodiscard]] std::uint32_t bin_size() const noexcept;
   [[nodiscard]] auto chromosomes() const noexcept -> const ChromosomeSet &;
   [[nodiscard]] auto bins() const noexcept -> const BinTable &;
+  [[nodiscard]] auto bins_ptr() const noexcept -> std::shared_ptr<const BinTable>;
 
   [[nodiscard]] auto attributes() const noexcept -> const StandardAttributes &;
   [[nodiscard]] auto group(std::string_view group_name) -> Group &;
@@ -195,6 +196,8 @@ class File {
   template <class N>
   [[nodiscard]] PixelSelector<N> fetch(std::string_view chrom1_name, std::uint32_t pos1,
                                        std::string_view chrom2_name, std::uint32_t pos2) const;
+  template <class N>
+  [[nodiscard]] PixelSelector<N> fetch(PixelCoordinates coord1, PixelCoordinates coord2) const;
 
   void flush();
 
@@ -239,7 +242,7 @@ class File {
   [[nodiscard]] static Index import_indexes(const Dataset &chrom_offset_dset,
                                             const Dataset &bin_offset_dset,
                                             const ChromosomeSet &chroms,
-                                            const BinTableLazy &bin_table,
+                                            std::shared_ptr<const BinTableLazy> bin_table,
                                             std::uint64_t expected_nnz, bool missing_ok);
 
   void validate_bins() const;

--- a/src/include/coolerpp/dataset.hpp
+++ b/src/include/coolerpp/dataset.hpp
@@ -249,6 +249,8 @@ class Dataset {
     [[nodiscard]] constexpr std::uint64_t h5_offset() const noexcept;
     [[nodiscard]] constexpr std::size_t underlying_buff_capacity() const noexcept;
 
+    constexpr const Dataset &dataset() const noexcept;
+
    private:
     void read_chunk_at_offset(std::size_t new_offset) const;
 

--- a/src/include/coolerpp/index.hpp
+++ b/src/include/coolerpp/index.hpp
@@ -23,7 +23,7 @@ class Index {
   using ChromID = std::uint32_t;
   using OffsetVect = std::vector<std::uint64_t>;
 
-  const BinTableLazy* _bins{};
+  std::shared_ptr<const BinTableLazy> _bins{};
   std::vector<OffsetVect> _idx{};
   std::size_t _size{};
   std::uint64_t _nnz{};
@@ -49,10 +49,11 @@ class Index {
   using const_iterator = iterator;
 
   Index() = default;
-  explicit Index(const BinTableLazy& bins, std::uint64_t nnz = 0);
+  explicit Index(std::shared_ptr<const BinTableLazy> bins, std::uint64_t nnz = 0);
 
   [[nodiscard]] const ChromosomeSet& chromosomes() const noexcept;
   [[nodiscard]] const BinTableLazy& bins() const noexcept;
+  [[nodiscard]] std::shared_ptr<const BinTableLazy> bins_ptr() const noexcept;
 
   [[nodiscard]] std::size_t num_chromosomes() const noexcept;
   [[nodiscard]] constexpr std::size_t size() const noexcept { return this->_size; }

--- a/src/include/coolerpp/pixel.hpp
+++ b/src/include/coolerpp/pixel.hpp
@@ -18,28 +18,29 @@ class BinTableLazy;
 struct Bin;
 
 class PixelCoordinates {
-  const BinTableLazy *_bins{};
+  std::shared_ptr<const BinTableLazy> _bins{};
   std::uint64_t _bin1_id{(std::numeric_limits<std::uint64_t>::max)()};  // NOLINT
   std::uint64_t _bin2_id{(std::numeric_limits<std::uint64_t>::max)()};  // NOLINT
 
  public:
   PixelCoordinates() = default;
-  PixelCoordinates(const BinTableLazy &bins, const Chromosome &chrom1, const Chromosome &chrom2,
-                   std::uint32_t bin1_start_, std::uint32_t bin2_start_);
-  PixelCoordinates(const BinTableLazy &bins, std::string_view chrom1_name,
+  PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, const Chromosome &chrom1,
+                   const Chromosome &chrom2, std::uint32_t bin1_start_, std::uint32_t bin2_start_);
+  PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, std::string_view chrom1_name,
                    std::string_view chrom2_name, std::uint32_t bin1_start_,
                    std::uint32_t bin2_start_);
-  PixelCoordinates(const BinTableLazy &bins, std::uint32_t chrom1_id_, std::uint32_t chrom2_id_,
+  PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, std::uint32_t chrom1_id_,
+                   std::uint32_t chrom2_id_, std::uint32_t bin1_start_, std::uint32_t bin2_start_);
+
+  PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, const Chromosome &chrom,
+                   std::uint32_t bin1_start_, std::uint32_t bin2_start_);
+  PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, std::string_view chrom_name,
+                   std::uint32_t bin1_start_, std::uint32_t bin2_start_);
+  PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, std::uint32_t chrom_id_,
                    std::uint32_t bin1_start_, std::uint32_t bin2_start_);
 
-  PixelCoordinates(const BinTableLazy &bins, const Chromosome &chrom, std::uint32_t bin1_start_,
-                   std::uint32_t bin2_start_);
-  PixelCoordinates(const BinTableLazy &bins, std::string_view chrom_name, std::uint32_t bin1_start_,
-                   std::uint32_t bin2_start_);
-  PixelCoordinates(const BinTableLazy &bins, std::uint32_t chrom_id_, std::uint32_t bin1_start_,
-                   std::uint32_t bin2_start_);
-
-  PixelCoordinates(const BinTableLazy &bins, std::uint64_t bin1_id, std::uint64_t bin2_id);
+  PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, std::uint64_t bin1_id,
+                   std::uint64_t bin2_id);
 
   [[nodiscard]] constexpr explicit operator bool() const noexcept;
   [[nodiscard]] constexpr bool operator==(const PixelCoordinates &other) const noexcept;

--- a/src/include/coolerpp/pixel.hpp
+++ b/src/include/coolerpp/pixel.hpp
@@ -24,19 +24,19 @@ class PixelCoordinates {
 
  public:
   PixelCoordinates() = default;
-  PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, const Chromosome &chrom1,
+  PixelCoordinates(const std::shared_ptr<const BinTableLazy> &bins, const Chromosome &chrom1,
                    const Chromosome &chrom2, std::uint32_t bin1_start_, std::uint32_t bin2_start_);
-  PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, std::string_view chrom1_name,
+  PixelCoordinates(const std::shared_ptr<const BinTableLazy> &bins, std::string_view chrom1_name,
                    std::string_view chrom2_name, std::uint32_t bin1_start_,
                    std::uint32_t bin2_start_);
-  PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, std::uint32_t chrom1_id_,
+  PixelCoordinates(const std::shared_ptr<const BinTableLazy> &bins, std::uint32_t chrom1_id_,
                    std::uint32_t chrom2_id_, std::uint32_t bin1_start_, std::uint32_t bin2_start_);
 
-  PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, const Chromosome &chrom,
+  PixelCoordinates(const std::shared_ptr<const BinTableLazy> &bins, const Chromosome &chrom,
                    std::uint32_t bin1_start_, std::uint32_t bin2_start_);
-  PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, std::string_view chrom_name,
+  PixelCoordinates(const std::shared_ptr<const BinTableLazy> &bins, std::string_view chrom_name,
                    std::uint32_t bin1_start_, std::uint32_t bin2_start_);
-  PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, std::uint32_t chrom_id_,
+  PixelCoordinates(const std::shared_ptr<const BinTableLazy> &bins, std::uint32_t chrom_id_,
                    std::uint32_t bin1_start_, std::uint32_t bin2_start_);
 
   PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, std::uint64_t bin1_id,

--- a/src/include/coolerpp/pixel.hpp
+++ b/src/include/coolerpp/pixel.hpp
@@ -15,18 +15,15 @@ namespace coolerpp {
 
 struct Chromosome;
 class BinTableLazy;
+struct Bin;
 
 class PixelCoordinates {
   const BinTableLazy *_bins{};
+  std::uint64_t _bin1_id{(std::numeric_limits<std::uint64_t>::max)()};  // NOLINT
+  std::uint64_t _bin2_id{(std::numeric_limits<std::uint64_t>::max)()};  // NOLINT
 
  public:
-  std::uint32_t chrom1_id{(std::numeric_limits<std::uint32_t>::max)()};  // NOLINT
-  std::uint32_t chrom2_id{(std::numeric_limits<std::uint32_t>::max)()};  // NOLINT
-
-  std::uint32_t bin1_start{};  // NOLINT
-  std::uint32_t bin2_start{};  // NOLINT
-
-  PixelCoordinates() = delete;
+  PixelCoordinates() = default;
   PixelCoordinates(const BinTableLazy &bins, const Chromosome &chrom1, const Chromosome &chrom2,
                    std::uint32_t bin1_start_, std::uint32_t bin2_start_);
   PixelCoordinates(const BinTableLazy &bins, std::string_view chrom1_name,
@@ -55,8 +52,14 @@ class PixelCoordinates {
   [[nodiscard]] const Chromosome &chrom1() const;
   [[nodiscard]] const Chromosome &chrom2() const;
 
-  [[nodiscard]] std::uint64_t bin1_id() const;
-  [[nodiscard]] std::uint64_t bin2_id() const;
+  [[nodiscard]] std::uint32_t chrom1_id() const;
+  [[nodiscard]] std::uint32_t chrom2_id() const;
+
+  [[nodiscard]] Bin bin1() const;
+  [[nodiscard]] Bin bin2() const;
+
+  [[nodiscard]] std::uint64_t bin1_id() const noexcept;
+  [[nodiscard]] std::uint64_t bin2_id() const noexcept;
 
   [[nodiscard]] std::uint32_t bin_size() const noexcept;
 };
@@ -92,9 +95,26 @@ struct fmt::formatter<coolerpp::PixelCoordinates> {
   template <typename FormatContext>
   auto format(const coolerpp::PixelCoordinates &c, FormatContext &ctx) const -> decltype(ctx.out());
 
- private:
   enum Presentation { raw, bedpe };
   Presentation presentation{Presentation::bedpe};
+};
+
+template <typename N>
+struct fmt::formatter<coolerpp::Pixel<N>> {
+  // Presentation can be any of the following:
+  //  - raw
+  //  - bedpe
+
+  constexpr auto parse(format_parse_context &ctx) -> decltype(ctx.begin());
+  // Formats the point p using the parsed format specification (presentation)
+  // stored in this formatter.
+  template <typename FormatContext>
+  auto format(const coolerpp::Pixel<N> &p, FormatContext &ctx) const -> decltype(ctx.out());
+
+ private:
+  fmt::formatter<coolerpp::PixelCoordinates> coord_formatter{};
+  using Presentation = typename decltype(coord_formatter)::Presentation;
+  [[nodiscard]] constexpr auto presentation() const noexcept -> Presentation;
 };
 
 #include "../../pixel_impl.hpp"

--- a/src/include/coolerpp/pixel.hpp
+++ b/src/include/coolerpp/pixel.hpp
@@ -42,7 +42,7 @@ class PixelCoordinates {
   PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, std::uint64_t bin1_id,
                    std::uint64_t bin2_id);
 
-  [[nodiscard]] constexpr explicit operator bool() const noexcept;
+  [[nodiscard]] explicit operator bool() const noexcept;
   [[nodiscard]] constexpr bool operator==(const PixelCoordinates &other) const noexcept;
   [[nodiscard]] constexpr bool operator!=(const PixelCoordinates &other) const noexcept;
   [[nodiscard]] constexpr bool operator<(const PixelCoordinates &other) const noexcept;
@@ -73,7 +73,7 @@ struct Pixel {
   Coordinates coords;
   N count;
 
-  [[nodiscard]] constexpr explicit operator bool() const noexcept;
+  [[nodiscard]] explicit operator bool() const noexcept;
   [[nodiscard]] constexpr bool operator==(const Pixel<N> &other) const noexcept;
   [[nodiscard]] constexpr bool operator!=(const Pixel<N> &other) const noexcept;
   [[nodiscard]] constexpr bool operator<(const Pixel<N> &other) const noexcept;

--- a/src/include/coolerpp/pixel_selector.hpp
+++ b/src/include/coolerpp/pixel_selector.hpp
@@ -129,6 +129,10 @@ class PixelSelector {
     void jump_to_row(std::uint64_t bin_id);
     void jump_to_col(std::uint64_t bin_id);
     void jump(std::uint64_t bin1_id, std::uint64_t bin2_id);
+    void jump_to_next_overlap();
+    [[nodiscard]] bool discard() const; // TODO rename
+    [[nodiscard]] std::size_t h5_offset() const noexcept;
+    void jump_at_end();
   };
 };
 

--- a/src/include/coolerpp/pixel_selector.hpp
+++ b/src/include/coolerpp/pixel_selector.hpp
@@ -68,7 +68,7 @@ class PixelSelector {
 
   class iterator {
     friend PixelSelector<N>;
-    const Index *_index{};
+    std::shared_ptr<const Index> _index{};
 
     std::shared_ptr<PixelCoordinates> _coord1{};
     std::shared_ptr<PixelCoordinates> _coord2{};
@@ -78,18 +78,18 @@ class PixelSelector {
     Dataset::iterator<std::uint64_t> _bin2_id_last{};
     Dataset::iterator<N> _count_it{};
 
-    explicit iterator(const Index &index, const Dataset &pixels_bin1_id,
+    explicit iterator(std::shared_ptr<const Index> index, const Dataset &pixels_bin1_id,
                       const Dataset &pixels_bin2_id, const Dataset &pixels_count);
 
-    explicit iterator(const Index &index, const Dataset &pixels_bin1_id,
+    explicit iterator(std::shared_ptr<const Index> index, const Dataset &pixels_bin1_id,
                       const Dataset &pixels_bin2_id, const Dataset &pixels_count,
                       std::shared_ptr<PixelCoordinates> coord1,
                       std::shared_ptr<PixelCoordinates> coord2);
 
-    static auto at_end(const Index &index, const Dataset &pixels_bin1_id,
+    static auto at_end(std::shared_ptr<const Index> index, const Dataset &pixels_bin1_id,
                        const Dataset &pixels_bin2_id, const Dataset &pixels_count) -> iterator;
 
-    static auto at_end(const Index &index, const Dataset &pixels_bin1_id,
+    static auto at_end(std::shared_ptr<const Index> index, const Dataset &pixels_bin1_id,
                        const Dataset &pixels_bin2_id, const Dataset &pixels_count,
                        std::shared_ptr<PixelCoordinates> coord1,
                        std::shared_ptr<PixelCoordinates> coord2) -> iterator;
@@ -130,7 +130,7 @@ class PixelSelector {
     void jump_to_col(std::uint64_t bin_id);
     void jump(std::uint64_t bin1_id, std::uint64_t bin2_id);
     void jump_to_next_overlap();
-    [[nodiscard]] bool discard() const; // TODO rename
+    [[nodiscard]] bool discard() const;
     [[nodiscard]] std::size_t h5_offset() const noexcept;
     void jump_at_end();
   };

--- a/src/include/coolerpp/pixel_selector.hpp
+++ b/src/include/coolerpp/pixel_selector.hpp
@@ -36,7 +36,7 @@ class PixelSelector {
 
   PixelSelector(std::shared_ptr<const Index> index, const Dataset &pixels_bin1_id,
                 const Dataset &pixels_bin2_id, const Dataset &pixels_count,
-                std::shared_ptr<PixelCoordinates> coords) noexcept;
+                const std::shared_ptr<PixelCoordinates> &coords) noexcept;
   PixelSelector(std::shared_ptr<const Index> index, const Dataset &pixels_bin1_id,
                 const Dataset &pixels_bin2_id, const Dataset &pixels_count,
                 std::shared_ptr<PixelCoordinates> coord1,

--- a/src/include/coolerpp/pixel_selector.hpp
+++ b/src/include/coolerpp/pixel_selector.hpp
@@ -29,26 +29,29 @@ class PixelSelector {
 
   std::shared_ptr<PixelCoordinates> _coord1{};
   std::shared_ptr<PixelCoordinates> _coord2{};
-  const Index *_index{};
+  std::shared_ptr<const Index> _index{};
   const Dataset *_pixels_bin1_id{};
   const Dataset *_pixels_bin2_id{};
   const Dataset *_pixels_count{};
 
-  PixelSelector(const Index &index, const Dataset &pixels_bin1_id, const Dataset &pixels_bin2_id,
-                const Dataset &pixels_count, std::shared_ptr<PixelCoordinates> coords) noexcept;
-  PixelSelector(const Index &index, const Dataset &pixels_bin1_id, const Dataset &pixels_bin2_id,
-                const Dataset &pixels_count, std::shared_ptr<PixelCoordinates> coord1,
+  PixelSelector(std::shared_ptr<const Index> index, const Dataset &pixels_bin1_id,
+                const Dataset &pixels_bin2_id, const Dataset &pixels_count,
+                std::shared_ptr<PixelCoordinates> coords) noexcept;
+  PixelSelector(std::shared_ptr<const Index> index, const Dataset &pixels_bin1_id,
+                const Dataset &pixels_bin2_id, const Dataset &pixels_count,
+                std::shared_ptr<PixelCoordinates> coord1,
                 std::shared_ptr<PixelCoordinates> coord2) noexcept;
 
  public:
   PixelSelector() = delete;
-  PixelSelector(const Index &index, const Dataset &pixels_bin1_id, const Dataset &pixels_bin2_id,
-                const Dataset &pixels_count) noexcept;
-  PixelSelector(const Index &index, const Dataset &pixels_bin1_id, const Dataset &pixels_bin2_id,
-                const Dataset &pixels_count, PixelCoordinates coords) noexcept;
+  PixelSelector(std::shared_ptr<const Index> index, const Dataset &pixels_bin1_id,
+                const Dataset &pixels_bin2_id, const Dataset &pixels_count) noexcept;
+  PixelSelector(std::shared_ptr<const Index> index, const Dataset &pixels_bin1_id,
+                const Dataset &pixels_bin2_id, const Dataset &pixels_count,
+                PixelCoordinates coords) noexcept;
 
-  PixelSelector(const Index &index, const Dataset &pixels_bin1_id, const Dataset &pixels_bin2_id,
-                const Dataset &pixels_count, PixelCoordinates coord1,
+  PixelSelector(std::shared_ptr<const Index> index, const Dataset &pixels_bin1_id,
+                const Dataset &pixels_bin2_id, const Dataset &pixels_count, PixelCoordinates coord1,
                 PixelCoordinates coord2) noexcept;
 
   [[nodiscard]] auto begin() const -> iterator;
@@ -60,7 +63,7 @@ class PixelSelector {
   [[nodiscard]] constexpr const PixelCoordinates &coord1() const noexcept;
   [[nodiscard]] constexpr const PixelCoordinates &coord2() const noexcept;
 
-  [[nodiscard]] static PixelCoordinates parse_query(const BinTableLazy &bins,
+  [[nodiscard]] static PixelCoordinates parse_query(const std::shared_ptr<const BinTableLazy> bins,
                                                     std::string_view query);
 
   class iterator {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -89,7 +89,7 @@ std::uint64_t Index::get_offset_by_bin_id(std::uint64_t bin_id) const {
     return this->_idx.back().back();
   }
   const auto &coords = this->_bins->bin_id_to_coords(bin_id);
-  return this->get_offset_by_pos(coords.chrom, coords.bin_start);
+  return this->get_offset_by_pos(coords.chrom, coords.start);
 }
 
 std::uint64_t Index::get_offset_by_pos(const Chromosome &chrom, std::uint32_t pos) const {
@@ -118,7 +118,7 @@ std::uint64_t Index::get_offset_by_row_idx(std::uint32_t chrom_id, std::size_t r
 
 void Index::set_offset_by_bin_id(std::uint64_t bin_id, std::uint64_t offset) {
   const auto &coords = this->_bins->bin_id_to_coords(bin_id);
-  this->set_offset_by_pos(coords.chrom, coords.bin_start, offset);
+  this->set_offset_by_pos(coords.chrom, coords.start, offset);
 }
 
 void Index::set_offset_by_pos(const Chromosome &chrom, std::uint32_t pos, std::uint64_t offset) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -21,8 +21,10 @@
 
 namespace coolerpp {
 
-Index::Index(const BinTableLazy &bins, std::uint64_t nnz)
-    : _bins(&bins), _idx(Index::init(bins.chromosomes(), _bins->bin_size())), _nnz(nnz) {
+Index::Index(std::shared_ptr<const BinTableLazy> bins, std::uint64_t nnz)
+    : _bins(std::move(bins)),
+      _idx(Index::init(_bins->chromosomes(), _bins->bin_size())),
+      _nnz(nnz) {
   assert(this->bin_size() != 0);
   _size = std::accumulate(_idx.begin(), _idx.end(), std::size_t(0),
                           [&](std::size_t sum, const auto &it) { return sum + it.size(); });
@@ -37,6 +39,8 @@ const BinTableLazy &Index::bins() const noexcept {
   assert(this->_bins);
   return *this->_bins;
 }
+
+std::shared_ptr<const BinTableLazy> Index::bins_ptr() const noexcept { return this->_bins; }
 
 std::size_t Index::num_chromosomes() const noexcept {
   assert(this->_idx.size() == this->_bins->num_chromosomes());

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -52,6 +52,8 @@ PixelCoordinates::PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, std
   assert(_bin2_id <= _bins->size());
 }
 
+PixelCoordinates::operator bool() const noexcept { return !!this->_bins; }
+
 const Chromosome &PixelCoordinates::chrom1() const { return this->bin1().chrom; }
 
 const Chromosome &PixelCoordinates::chrom2() const { return this->bin2().chrom; }

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -13,41 +13,43 @@
 
 namespace coolerpp {
 
-PixelCoordinates::PixelCoordinates(const BinTableLazy &bins, const Chromosome &chrom1,
-                                   const Chromosome &chrom2, std::uint32_t bin1_start_,
-                                   std::uint32_t bin2_start_)
-    : PixelCoordinates(bins, bins.chromosomes().get_id(chrom1), bins.chromosomes().get_id(chrom2),
+PixelCoordinates::PixelCoordinates(std::shared_ptr<const BinTableLazy> bins,
+                                   const Chromosome &chrom1, const Chromosome &chrom2,
+                                   std::uint32_t bin1_start_, std::uint32_t bin2_start_)
+    : PixelCoordinates(bins, bins->chromosomes().get_id(chrom1), bins->chromosomes().get_id(chrom2),
                        bin1_start_, bin2_start_) {}
 
-PixelCoordinates::PixelCoordinates(const BinTableLazy &bins, std::string_view chrom1_name,
-                                   std::string_view chrom2_name, std::uint32_t bin1_start_,
+PixelCoordinates::PixelCoordinates(std::shared_ptr<const BinTableLazy> bins,
+                                   std::string_view chrom1_name, std::string_view chrom2_name,
+                                   std::uint32_t bin1_start_, std::uint32_t bin2_start_)
+    : PixelCoordinates(bins, bins->chromosomes().get_id(chrom1_name),
+                       bins->chromosomes().get_id(chrom2_name), bin1_start_, bin2_start_) {}
+
+PixelCoordinates::PixelCoordinates(std::shared_ptr<const BinTableLazy> bins,
+                                   std::uint32_t chrom1_id_, std::uint32_t chrom2_id_,
+                                   std::uint32_t bin1_start_, std::uint32_t bin2_start_)
+    : PixelCoordinates(bins, bins->coord_to_bin_id(chrom1_id_, bin1_start_),
+                       bins->coord_to_bin_id(chrom2_id_, bin2_start_)) {}
+
+PixelCoordinates::PixelCoordinates(std::shared_ptr<const BinTableLazy> bins,
+                                   const Chromosome &chrom, std::uint32_t bin1_start_,
                                    std::uint32_t bin2_start_)
-    : PixelCoordinates(bins, bins.chromosomes().get_id(chrom1_name),
-                       bins.chromosomes().get_id(chrom2_name), bin1_start_, bin2_start_) {}
+    : PixelCoordinates(std::move(bins), chrom, chrom, bin1_start_, bin2_start_) {}
 
-PixelCoordinates::PixelCoordinates(const BinTableLazy &bins, std::uint32_t chrom1_id_,
-                                   std::uint32_t chrom2_id_, std::uint32_t bin1_start_,
+PixelCoordinates::PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, std::uint32_t chrom_id,
+                                   std::uint32_t bin1_start_, std::uint32_t bin2_start_)
+    : PixelCoordinates(std::move(bins), chrom_id, chrom_id, bin1_start_, bin2_start_) {}
+
+PixelCoordinates::PixelCoordinates(std::shared_ptr<const BinTableLazy> bins,
+                                   std::string_view chrom_name, std::uint32_t bin1_start_,
                                    std::uint32_t bin2_start_)
-    : PixelCoordinates(bins, bins.coord_to_bin_id(chrom1_id_, bin1_start_),
-                       bins.coord_to_bin_id(chrom2_id_, bin2_start_)) {}
+    : PixelCoordinates(std::move(bins), chrom_name, chrom_name, bin1_start_, bin2_start_) {}
 
-PixelCoordinates::PixelCoordinates(const BinTableLazy &bins, const Chromosome &chrom,
-                                   std::uint32_t bin1_start_, std::uint32_t bin2_start_)
-    : PixelCoordinates(bins, chrom, chrom, bin1_start_, bin2_start_) {}
-
-PixelCoordinates::PixelCoordinates(const BinTableLazy &bins, std::uint32_t chrom_id,
-                                   std::uint32_t bin1_start_, std::uint32_t bin2_start_)
-    : PixelCoordinates(bins, chrom_id, chrom_id, bin1_start_, bin2_start_) {}
-
-PixelCoordinates::PixelCoordinates(const BinTableLazy &bins, std::string_view chrom_name,
-                                   std::uint32_t bin1_start_, std::uint32_t bin2_start_)
-    : PixelCoordinates(bins, chrom_name, chrom_name, bin1_start_, bin2_start_) {}
-
-PixelCoordinates::PixelCoordinates(const BinTableLazy &bins, std::uint64_t bin1_id_,
+PixelCoordinates::PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, std::uint64_t bin1_id_,
                                    std::uint64_t bin2_id_)
-    : _bins(&bins), _bin1_id(bin1_id_), _bin2_id(bin2_id_) {
-  assert(_bin1_id <= bins.size());
-  assert(_bin2_id <= bins.size());
+    : _bins(std::move(bins)), _bin1_id(bin1_id_), _bin2_id(bin2_id_) {
+  assert(_bin1_id <= _bins->size());
+  assert(_bin2_id <= _bins->size());
 }
 
 const Chromosome &PixelCoordinates::chrom1() const { return this->bin1().chrom; }

--- a/src/pixel.cpp
+++ b/src/pixel.cpp
@@ -13,40 +13,41 @@
 
 namespace coolerpp {
 
-PixelCoordinates::PixelCoordinates(std::shared_ptr<const BinTableLazy> bins,
+PixelCoordinates::PixelCoordinates(const std::shared_ptr<const BinTableLazy> &bins,
                                    const Chromosome &chrom1, const Chromosome &chrom2,
                                    std::uint32_t bin1_start_, std::uint32_t bin2_start_)
     : PixelCoordinates(bins, bins->chromosomes().get_id(chrom1), bins->chromosomes().get_id(chrom2),
                        bin1_start_, bin2_start_) {}
 
-PixelCoordinates::PixelCoordinates(std::shared_ptr<const BinTableLazy> bins,
+PixelCoordinates::PixelCoordinates(const std::shared_ptr<const BinTableLazy> &bins,
                                    std::string_view chrom1_name, std::string_view chrom2_name,
                                    std::uint32_t bin1_start_, std::uint32_t bin2_start_)
     : PixelCoordinates(bins, bins->chromosomes().get_id(chrom1_name),
                        bins->chromosomes().get_id(chrom2_name), bin1_start_, bin2_start_) {}
 
-PixelCoordinates::PixelCoordinates(std::shared_ptr<const BinTableLazy> bins,
+PixelCoordinates::PixelCoordinates(const std::shared_ptr<const BinTableLazy> &bins,
                                    std::uint32_t chrom1_id_, std::uint32_t chrom2_id_,
                                    std::uint32_t bin1_start_, std::uint32_t bin2_start_)
     : PixelCoordinates(bins, bins->coord_to_bin_id(chrom1_id_, bin1_start_),
                        bins->coord_to_bin_id(chrom2_id_, bin2_start_)) {}
 
-PixelCoordinates::PixelCoordinates(std::shared_ptr<const BinTableLazy> bins,
+PixelCoordinates::PixelCoordinates(const std::shared_ptr<const BinTableLazy> &bins,
                                    const Chromosome &chrom, std::uint32_t bin1_start_,
                                    std::uint32_t bin2_start_)
-    : PixelCoordinates(std::move(bins), chrom, chrom, bin1_start_, bin2_start_) {}
+    : PixelCoordinates(bins, chrom, chrom, bin1_start_, bin2_start_) {}
 
-PixelCoordinates::PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, std::uint32_t chrom_id,
-                                   std::uint32_t bin1_start_, std::uint32_t bin2_start_)
-    : PixelCoordinates(std::move(bins), chrom_id, chrom_id, bin1_start_, bin2_start_) {}
+PixelCoordinates::PixelCoordinates(const std::shared_ptr<const BinTableLazy> &bins,
+                                   std::uint32_t chrom_id, std::uint32_t bin1_start_,
+                                   std::uint32_t bin2_start_)
+    : PixelCoordinates(bins, chrom_id, chrom_id, bin1_start_, bin2_start_) {}
 
-PixelCoordinates::PixelCoordinates(std::shared_ptr<const BinTableLazy> bins,
+PixelCoordinates::PixelCoordinates(const std::shared_ptr<const BinTableLazy> &bins,
                                    std::string_view chrom_name, std::uint32_t bin1_start_,
                                    std::uint32_t bin2_start_)
-    : PixelCoordinates(std::move(bins), chrom_name, chrom_name, bin1_start_, bin2_start_) {}
+    : PixelCoordinates(bins, chrom_name, chrom_name, bin1_start_, bin2_start_) {}
 
-PixelCoordinates::PixelCoordinates(std::shared_ptr<const BinTableLazy> bins, std::uint64_t bin1_id_,
-                                   std::uint64_t bin2_id_)
+PixelCoordinates::PixelCoordinates(std::shared_ptr<const BinTableLazy> bins,
+                                   std::uint64_t bin1_id_, std::uint64_t bin2_id_)
     : _bins(std::move(bins)), _bin1_id(bin1_id_), _bin2_id(bin2_id_) {
   assert(_bin1_id <= _bins->size());
   assert(_bin2_id <= _bins->size());

--- a/src/pixel_impl.hpp
+++ b/src/pixel_impl.hpp
@@ -10,8 +10,6 @@
 
 namespace coolerpp {
 
-constexpr PixelCoordinates::operator bool() const noexcept { return !!this->_bins; }
-
 constexpr bool PixelCoordinates::operator==(const PixelCoordinates &other) const noexcept {
   return this->_bin1_id == other._bin1_id && this->_bin2_id == other._bin2_id;
 }
@@ -49,7 +47,7 @@ constexpr bool PixelCoordinates::operator>=(const PixelCoordinates &other) const
 }
 
 template <typename N>
-constexpr Pixel<N>::operator bool() const noexcept {
+inline Pixel<N>::operator bool() const noexcept {
   return !!this->coords;
 }
 template <typename N>

--- a/src/pixel_impl.hpp
+++ b/src/pixel_impl.hpp
@@ -10,14 +10,10 @@
 
 namespace coolerpp {
 
-constexpr PixelCoordinates::operator bool() const noexcept {
-  return this->chrom1_id != (std::numeric_limits<std::uint32_t>::max)() &&
-         this->chrom2_id != (std::numeric_limits<std::uint32_t>::max)();
-}
+constexpr PixelCoordinates::operator bool() const noexcept { return !!this->_bins; }
 
 constexpr bool PixelCoordinates::operator==(const PixelCoordinates &other) const noexcept {
-  return this->chrom1_id == other.chrom1_id && this->chrom2_id == other.chrom2_id &&
-         this->bin1_start == other.bin1_start && this->bin2_start == other.bin2_start;
+  return this->_bin1_id == other._bin1_id && this->_bin2_id == other._bin2_id;
 }
 
 constexpr bool PixelCoordinates::operator!=(const PixelCoordinates &other) const noexcept {
@@ -25,59 +21,31 @@ constexpr bool PixelCoordinates::operator!=(const PixelCoordinates &other) const
 }
 
 constexpr bool PixelCoordinates::operator<(const PixelCoordinates &other) const noexcept {
-  if (this->chrom1_id != other.chrom1_id) {
-    return this->chrom1_id < other.chrom1_id;
+  if (this->_bin1_id == other._bin1_id) {
+    return this->_bin2_id < other._bin2_id;
   }
-  if (this->bin1_start != other.bin1_start) {
-    return this->bin1_start < other.bin1_start;
-  }
-
-  if (this->chrom2_id != other.chrom2_id) {
-    return this->chrom2_id < other.chrom2_id;
-  }
-  return this->bin2_start < other.bin2_start;
+  return this->_bin1_id < other._bin1_id;
 }
 
 constexpr bool PixelCoordinates::operator<=(const PixelCoordinates &other) const noexcept {
-  if (this->chrom1_id != other.chrom1_id) {
-    return this->chrom1_id <= other.chrom1_id;
+  if (this->_bin1_id == other._bin1_id) {
+    return this->_bin2_id <= other._bin2_id;
   }
-  if (this->bin1_start != other.bin1_start) {
-    return this->bin1_start <= other.bin1_start;
-  }
-
-  if (this->chrom2_id != other.chrom2_id) {
-    return this->chrom2_id <= other.chrom2_id;
-  }
-  return this->bin2_start <= other.bin2_start;
+  return this->_bin1_id <= other._bin1_id;
 }
 
 constexpr bool PixelCoordinates::operator>(const PixelCoordinates &other) const noexcept {
-  if (this->chrom1_id != other.chrom1_id) {
-    return this->chrom1_id > other.chrom1_id;
+  if (this->_bin1_id == other._bin1_id) {
+    return this->_bin2_id > other._bin2_id;
   }
-  if (this->bin1_start != other.bin1_start) {
-    return this->bin1_start > other.bin1_start;
-  }
-
-  if (this->chrom2_id != other.chrom2_id) {
-    return this->chrom2_id > other.chrom2_id;
-  }
-  return this->bin2_start > other.bin2_start;
+  return this->_bin1_id > other._bin1_id;
 }
 
 constexpr bool PixelCoordinates::operator>=(const PixelCoordinates &other) const noexcept {
-  if (this->chrom1_id != other.chrom1_id) {
-    return this->chrom1_id >= other.chrom1_id;
+  if (this->_bin1_id == other._bin1_id) {
+    return this->_bin2_id >= other._bin2_id;
   }
-  if (this->bin1_start != other.bin1_start) {
-    return this->bin1_start >= other.bin1_start;
-  }
-
-  if (this->chrom2_id != other.chrom2_id) {
-    return this->chrom2_id >= other.chrom2_id;
-  }
-  return this->bin2_start >= other.bin2_start;
+  return this->_bin1_id >= other._bin1_id;
 }
 
 template <typename N>
@@ -86,7 +54,7 @@ constexpr Pixel<N>::operator bool() const noexcept {
 }
 template <typename N>
 constexpr bool Pixel<N>::operator==(const Pixel<N> &other) const noexcept {
-  return this->coords == other.coords;
+  return this->coords == other.coords && this->count == other.count;
 }
 template <typename N>
 constexpr bool Pixel<N>::operator!=(const Pixel<N> &other) const noexcept {
@@ -128,17 +96,13 @@ constexpr auto fmt::formatter<coolerpp::PixelCoordinates>::parse(format_parse_co
     }
   }
 
-  // Check if reached the end of the range:
   if (it != end && *it != '}') {
     throw fmt::format_error("invalid format");
   }
 
-  // Return an iterator past the end of the parsed range:
   return it;
 }
 
-// Formats the point p using the parsed format specification (presentation)
-// stored in this formatter.
 template <typename FormatContext>
 inline auto fmt::formatter<coolerpp::PixelCoordinates>::format(const coolerpp::PixelCoordinates &c,
                                                                FormatContext &ctx) const
@@ -152,14 +116,41 @@ inline auto fmt::formatter<coolerpp::PixelCoordinates>::format(const coolerpp::P
   }
 
   assert(this->presentation == Presentation::bedpe);
+  const auto bin1 = c.bin1();
+  const auto bin2 = c.bin2();
   // clang-format off
   return fmt::format_to(ctx.out(),
                         FMT_STRING("{}\t{}\t{}\t{}\t{}\t{}"),
-                        c.chrom1().name,
-                        c.bin1_start,
-                        (std::min)(c.bin1_start + c.bin_size(), c.chrom1().size),
-                        c.chrom2().name,
-                        c.bin2_start,
-                        (std::min)(c.bin2_start + c.bin_size(), c.chrom2().size));
+                        bin1.chrom.name,
+                        bin1.start,
+                        (std::min)(bin1.start + c.bin_size(), bin1.chrom.size),
+                        bin2.chrom.name,
+                        bin2.start,
+                        (std::min)(bin2.start + c.bin_size(), bin2.chrom.size));
   // clang-format on
+}
+
+template <typename N>
+constexpr auto fmt::formatter<coolerpp::Pixel<N>>::parse(format_parse_context &ctx)
+    -> decltype(ctx.begin()) {
+  this->coord_formatter.parse(ctx);
+  return ctx.end();
+}
+
+template <typename N>
+constexpr auto fmt::formatter<coolerpp::Pixel<N>>::presentation() const noexcept -> Presentation {
+  return this->coord_formatter.presentation;
+}
+
+template <typename N>
+template <typename FormatContext>
+inline auto fmt::formatter<coolerpp::Pixel<N>>::format(const coolerpp::Pixel<N> &p,
+                                                       FormatContext &ctx) const
+    -> decltype(ctx.out()) {
+  if (this->presentation() == Presentation::raw) {
+    return fmt::format_to(ctx.out(), FMT_STRING("{:raw}\t{}"), p.coords, p.count);
+  }
+
+  assert(this->presentation() == Presentation::bedpe);
+  return fmt::format_to(ctx.out(), FMT_STRING("{:bedpe}\t{}"), p.coords, p.count);
 }

--- a/src/pixel_selector_impl.hpp
+++ b/src/pixel_selector_impl.hpp
@@ -17,22 +17,42 @@ namespace coolerpp {
 template <class N>
 inline PixelSelector<N>::PixelSelector(const Index &index, const Dataset &pixels_bin1_id,
                                        const Dataset &pixels_bin2_id, const Dataset &pixels_count,
-                                       PixelCoordinates coords)
-    : _coords(std::move(coords)),
+                                       std::shared_ptr<PixelCoordinates> coords) noexcept
+    : PixelSelector(index, pixels_bin1_id, pixels_bin2_id, pixels_count, coords,
+                    std::move(coords)) {}
+
+template <class N>
+inline PixelSelector<N>::PixelSelector(const Index &index, const Dataset &pixels_bin1_id,
+                                       const Dataset &pixels_bin2_id, const Dataset &pixels_count,
+                                       std::shared_ptr<PixelCoordinates> coord1,
+                                       std::shared_ptr<PixelCoordinates> coord2) noexcept
+    : _coord1(std::move(coord1)),
+      _coord2(std::move(coord2)),
       _index(&index),
       _pixels_bin1_id(&pixels_bin1_id),
       _pixels_bin2_id(&pixels_bin2_id),
-      _pixels_count(&pixels_count),
-      _empty(_coords.chrom1_id == _coords.chrom2_id && _coords.bin1_start == _coords.bin2_start) {
-  if (_coords.bin2_start != 0) {
-    _coords.bin2_start--;
-  }
-}
+      _pixels_count(&pixels_count) {}
 
 template <class N>
-constexpr bool PixelSelector<N>::empty() const noexcept {
-  return this->_empty;
-}
+inline PixelSelector<N>::PixelSelector(const Index &index, const Dataset &pixels_bin1_id,
+                                       const Dataset &pixels_bin2_id, const Dataset &pixels_count,
+                                       PixelCoordinates coords) noexcept
+    : PixelSelector<N>(index, pixels_bin1_id, pixels_bin2_id, pixels_count,
+                       std::make_shared<PixelCoordinates>(std::move(coords))) {}
+
+template <class N>
+inline PixelSelector<N>::PixelSelector(const Index &index, const Dataset &pixels_bin1_id,
+                                       const Dataset &pixels_bin2_id,
+                                       const Dataset &pixels_count) noexcept
+    : PixelSelector<N>(index, pixels_bin1_id, pixels_bin2_id, pixels_count, nullptr, nullptr) {}
+
+template <class N>
+inline PixelSelector<N>::PixelSelector(const Index &index, const Dataset &pixels_bin1_id,
+                                       const Dataset &pixels_bin2_id, const Dataset &pixels_count,
+                                       PixelCoordinates coord1, PixelCoordinates coord2) noexcept
+    : PixelSelector(index, pixels_bin1_id, pixels_bin2_id, pixels_count,
+                    std::make_shared<PixelCoordinates>(std::move(coord1)),
+                    std::make_shared<PixelCoordinates>(std::move(coord2))) {}
 
 template <class N>
 inline auto PixelSelector<N>::begin() const -> iterator {
@@ -46,21 +66,30 @@ inline auto PixelSelector<N>::end() const -> iterator {
 
 template <class N>
 inline auto PixelSelector<N>::cbegin() const -> iterator {
-  if (this->empty()) {
-    return this->cend();
+  if (!this->_coord1) {
+    assert(!this->_coord2);
+    return iterator{*this->_index, *this->_pixels_bin1_id, *this->_pixels_bin2_id,
+                    *this->_pixels_count};
   }
-  return iterator{*this->_index, *this->_pixels_bin1_id, *this->_pixels_bin2_id,
-                  *this->_pixels_count, this->_coords};
+
+  return iterator{*this->_index,        *this->_pixels_bin1_id, *this->_pixels_bin2_id,
+                  *this->_pixels_count, this->_coord1,          this->_coord2};
 }
 
 template <class N>
 inline auto PixelSelector<N>::cend() const -> iterator {
-  return iterator::make_end_iterator(*this->_index, *this->_pixels_bin2_id, this->_coords);
+  return iterator::at_end(*this->_index, *this->_pixels_bin1_id, *this->_pixels_bin2_id,
+                          *this->_pixels_count, this->_coord1, this->_coord2);
 }
 
 template <class N>
-constexpr const PixelCoordinates &PixelSelector<N>::coords() const noexcept {
-  return this->_coords;
+constexpr const PixelCoordinates &PixelSelector<N>::coord1() const noexcept {
+  return this->_coord1;
+}
+
+template <class N>
+constexpr const PixelCoordinates &PixelSelector<N>::coord2() const noexcept {
+  return this->_coord2;
 }
 
 template <class N>
@@ -123,83 +152,104 @@ inline PixelCoordinates PixelSelector<N>::parse_query(const BinTableLazy &bins,
                     end_pos, query, end_pos, chrom.size));
   }
 
-  if (start_pos > end_pos) {
-    throw std::runtime_error(fmt::format(FMT_STRING("invalid query \"{}\": query start position is "
-                                                    "greater than end position ({} > {})"),
-                                         query, start_pos, end_pos));
+  if (start_pos >= end_pos) {
+    throw std::runtime_error(
+        fmt::format(FMT_STRING("invalid query \"{}\": query end position should be "
+                               "greater than the start position ({} >= {})"),
+                    query, start_pos, end_pos));
   }
 
+  end_pos -= std::min(end_pos, 1U);
   return {bins, chrom, start_pos, end_pos};
-}
-
-template <class N>
-inline std::uint64_t PixelSelector<N>::compute_end_offset(const Index &index,
-                                                          const Dataset &bin2_id_dset,
-                                                          std::uint64_t last_bin2_id) {
-  assert(last_bin2_id != 0);
-  if (last_bin2_id == index.size() || last_bin2_id == index.size() + 1) {
-    return bin2_id_dset.size();
-  }
-
-  const auto lower_bound = index.get_offset_by_bin_id(last_bin2_id - 1);
-  const auto upper_bound = index.get_offset_by_bin_id(last_bin2_id);
-
-  auto lb = bin2_id_dset.make_iterator_at_offset<std::uint64_t>(lower_bound, 1);
-  auto ub = bin2_id_dset.make_iterator_at_offset<std::uint64_t>(upper_bound, 1);
-
-  auto it = std::lower_bound(lb, ub, last_bin2_id);
-  return lower_bound + static_cast<std::uint64_t>(std::distance(lb, it));
 }
 
 template <class N>
 inline PixelSelector<N>::iterator::iterator(const Index &index, const Dataset &pixels_bin1_id,
                                             const Dataset &pixels_bin2_id,
-                                            const Dataset &pixels_count,
-                                            const coolerpp::PixelCoordinates &coords) noexcept
+                                            const Dataset &pixels_count)
     : _index(&index),
-      _first_chrom_id(index.chromosomes().get_id(coords.chrom1().name)),
-      _last_chrom_id(index.chromosomes().get_id(coords.chrom2().name) + 1),
-      _first_bin_id(coords.bin1_id()),
-      _last_bin_id(coords.bin2_id() + 1),
-      _bin1_id_it(pixels_bin1_id.make_iterator_at_offset<std::uint64_t>(
-          index.get_offset_by_bin_id(_first_bin_id))),
-      _bin2_id_it(pixels_bin2_id.make_iterator_at_offset<std::uint64_t>(
-          index.get_offset_by_bin_id(_first_bin_id))),
-      _bin2_id_last(pixels_bin2_id.make_iterator_at_offset<std::uint64_t>(
-          compute_end_offset(index, pixels_bin2_id, _last_bin_id))),
-      _count_it(
-          pixels_count.make_iterator_at_offset<N>(index.get_offset_by_bin_id(_first_bin_id))) {
-  assert(_first_chrom_id <= _last_chrom_id);
-  assert(_first_bin_id < _last_bin_id);
+      _coord1(nullptr),
+      _coord2(nullptr),
+      _bin1_id_it(pixels_bin1_id.begin<std::uint64_t>()),
+      _bin2_id_it(pixels_bin2_id.begin<std::uint64_t>()),
+      _bin2_id_last(pixels_bin2_id.end<std::uint64_t>()),
+      _count_it(pixels_count.begin<N>()) {}
+
+template <class N>
+inline PixelSelector<N>::iterator::iterator(const Index &index, const Dataset &pixels_bin1_id,
+                                            const Dataset &pixels_bin2_id,
+                                            const Dataset &pixels_count,
+                                            std::shared_ptr<PixelCoordinates> coord1,
+                                            std::shared_ptr<PixelCoordinates> coord2)
+    : _index(&index), _coord1(std::move(coord1)), _coord2(std::move(coord2)) {
+  assert(_coord1);
+  assert(_coord2);
+  assert(_coord1->bin1_id() <= _coord1->bin2_id());
+  assert(_coord2->bin1_id() <= _coord2->bin2_id());
+
+  auto offset = _index->get_offset_by_bin_id(_coord1->bin1_id());
+  _bin1_id_it = pixels_bin1_id.make_iterator_at_offset<std::uint64_t>(offset);
+  _bin2_id_it = pixels_bin2_id.make_iterator_at_offset<std::uint64_t>(offset);
+  _bin2_id_last = pixels_bin2_id.end<std::uint64_t>();
+  _count_it = pixels_count.make_iterator_at_offset<N>(offset);
+
+  this->jump(_coord1->bin1_id(), _coord2->bin1_id());
+
+  auto it = iterator::at_end(index, pixels_bin1_id, pixels_bin2_id, pixels_count, _coord1, _coord2);
+  _bin2_id_last = it._bin2_id_it;
+  assert(_bin2_id_it <= _bin2_id_last);
 }
 
 template <class N>
-inline auto PixelSelector<N>::iterator::make_end_iterator(const Index &index,
-                                                          const Dataset &pixels_bin2_id,
-                                                          const PixelCoordinates &coords)
+inline auto PixelSelector<N>::iterator::at_end(const Index &index, const Dataset &pixels_bin1_id,
+                                               const Dataset &pixels_bin2_id,
+                                               const Dataset &pixels_count) -> iterator {
+  iterator it{};
+  it._index = &index;
+  it._bin1_id_it = pixels_bin1_id.end<std::uint64_t>();
+  it._bin2_id_it = pixels_bin2_id.end<std::uint64_t>();
+  it._bin2_id_last = it._bin2_id_it;
+  it._count_it = pixels_count.end<N>();
+
+  return it;
+}
+
+template <class N>
+inline auto PixelSelector<N>::iterator::at_end(const Index &index, const Dataset &pixels_bin1_id,
+                                               const Dataset &pixels_bin2_id,
+                                               const Dataset &pixels_count,
+                                               std::shared_ptr<PixelCoordinates> coord1,
+                                               std::shared_ptr<PixelCoordinates> coord2)
     -> iterator {
+  if (!coord1 && !coord2) {
+    return at_end(index, pixels_bin1_id, pixels_bin2_id, pixels_count);
+  }
+  assert(!!coord1);
+  assert(!!coord2);
+
   iterator it{};
 
   it._index = &index;
-  it._first_chrom_id = coords.chrom1_id;
-  it._last_chrom_id = coords.chrom2_id + 1;
+  it._coord1 = std::move(coord1);
+  it._coord2 = std::move(coord2);
 
-  it._first_bin_id = coords.bin1_id();
-  it._last_bin_id = coords.bin2_id() + 1;
-  it._bin2_id_last = pixels_bin2_id.make_iterator_at_offset<std::uint64_t>(
-      compute_end_offset(index, pixels_bin2_id, it._last_bin_id));
+  const auto offset = index.get_offset_by_bin_id(it._coord1->bin2_id());
+  it._bin1_id_it = pixels_bin1_id.make_iterator_at_offset<std::uint64_t>(offset);
+  it._bin2_id_it = pixels_bin2_id.make_iterator_at_offset<std::uint64_t>(offset);
+  it._bin2_id_last = pixels_bin2_id.end<std::uint64_t>();
+  it._count_it = pixels_count.make_iterator_at_offset<N>(offset);
 
-  it._bin2_id_it = it._bin2_id_last;
+  it.jump(it._coord1->bin2_id(), std::max(it._coord1->bin2_id(), it._coord2->bin2_id()));
+
+  it._bin2_id_last = ++it._bin2_id_it;
 
   return it;
 }
 
 template <class N>
 constexpr bool PixelSelector<N>::iterator::operator==(const iterator &other) const noexcept {
-  // clang-format off
-  return this->_index == other._index &&
-         this->_bin2_id_it == other._bin2_id_it;
-  // clang-format on
+  assert(this->_index == other._index);
+  return this->_bin2_id_it == other._bin2_id_it;
 }
 template <class N>
 constexpr bool PixelSelector<N>::iterator::operator!=(const iterator &other) const noexcept {
@@ -208,38 +258,31 @@ constexpr bool PixelSelector<N>::iterator::operator!=(const iterator &other) con
 
 template <class N>
 constexpr bool PixelSelector<N>::iterator::operator<(const iterator &other) const noexcept {
-  // clang-format off
-  return this->_index < other._index &&
-         this->_bin2_id_it < other._bin2_id_it;
-  // clang-format on
+  assert(this->_index == other._index);
+  return this->_bin2_id_it < other._bin2_id_it;
 }
 template <class N>
 constexpr bool PixelSelector<N>::iterator::operator<=(const iterator &other) const noexcept {
-  // clang-format off
-  return this->_index <= other._index &&
-         this->_bin2_id_it <= other._bin2_id_it;
-  // clang-format on
+  assert(this->_index == other._index);
+  return this->_bin2_id_it <= other._bin2_id_it;
 }
 
 template <class N>
 constexpr bool PixelSelector<N>::iterator::operator>(const iterator &other) const noexcept {
-  // clang-format off
-  return this->_index > other._index &&
-         this->_bin2_id_it > other._bin2_id_it;
-  // clang-format on
+  assert(this->_index == other._index);
+  return this->_bin2_id_it > other._bin2_id_it;
 }
 template <class N>
 constexpr bool PixelSelector<N>::iterator::operator>=(const iterator &other) const noexcept {
-  // clang-format off
-  return this->_index >= other._index &&
-         this->_bin2_id_it >= other._bin2_id_it;
-  // clang-format on
+  assert(this->_index == other._index);
+  return this->_bin2_id_it >= other._bin2_id_it;
 }
 
 template <class N>
 inline auto PixelSelector<N>::iterator::operator*() const -> value_type {
+  assert(this->_index);
+  assert(this->_bin2_id_it < this->_bin2_id_last);
   // clang-format off
-  assert(this->_bin2_id_it != this->_bin2_id_last);
   return {PixelCoordinates{this->_index->bins(),
                            *this->_bin1_id_it,
                            *this->_bin2_id_it},
@@ -249,27 +292,25 @@ inline auto PixelSelector<N>::iterator::operator*() const -> value_type {
 
 template <class N>
 inline auto PixelSelector<N>::iterator::operator++() -> iterator & {
-  if (++this->_bin2_id_it >= this->_bin2_id_last) {
-    ++this->_bin1_id_it;
-    ++this->_count_it;
+  if (!this->_coord1) {
+    assert(!this->_coord2);
+    std::ignore = ++this->_bin1_id_it;
+    std::ignore = ++this->_bin2_id_it;
+    std::ignore = ++this->_count_it;
     return *this;
   }
 
-  if (*this->_bin2_id_it == this->_last_bin_id) {
-    assert(*this->_bin1_id_it < this->_last_bin_id);
-
-    const auto new_offset = this->_index->get_offset_by_bin_id((*this->_bin1_id_it) + 1);
-    const auto relative_offset = new_offset - this->_bin1_id_it.h5_offset();
-    assert(relative_offset != 0);
-
-    this->_bin1_id_it += relative_offset;
-    this->_bin2_id_it += relative_offset - 1;
-    this->_count_it += relative_offset;
-
-    return *this;
+  if (this->_bin2_id_it < this->_bin2_id_last && *this->_bin2_id_it >= this->_coord2->bin2_id()) {
+    const auto row = *this->_bin1_id_it + 1;
+    if (row <= this->_coord1->bin2_id()) {
+      const auto col = std::max(row, this->_coord2->bin1_id());
+      this->jump(row, col);
+      return *this;
+    }
   }
 
   std::ignore = ++this->_bin1_id_it;
+  std::ignore = ++this->_bin2_id_it;
   std::ignore = ++this->_count_it;
 
   return *this;
@@ -280,6 +321,72 @@ inline auto PixelSelector<N>::iterator::operator++(int) -> iterator {
   auto it = *this;
   std::ignore = ++(*this);
   return it;
+}
+
+template <class N>
+inline void PixelSelector<N>::iterator::jump_to_row(std::uint64_t bin_id) {
+  assert(this->_index);
+  assert(bin_id <= this->_index->bins().size());
+
+  auto offset = this->_index->get_offset_by_bin_id(bin_id);
+
+  const auto &bin2_id_dset = _bin2_id_it.dataset();
+  const auto &bin1_id_dset = _bin1_id_it.dataset();
+  const auto &count_dset = _count_it.dataset();
+
+  this->_bin1_id_it = bin1_id_dset.make_iterator_at_offset<std::uint64_t>(offset);
+  this->_bin2_id_it = bin2_id_dset.make_iterator_at_offset<std::uint64_t>(offset);
+  this->_count_it = count_dset.template make_iterator_at_offset<N>(offset);
+
+  assert(this->_bin2_id_it <= this->_bin2_id_last);
+}
+
+template <class N>
+inline void PixelSelector<N>::iterator::jump_to_col(std::uint64_t bin_id) {
+  assert(this->_index);
+  assert(bin_id <= this->_index->bins().size());
+
+  const auto current_row = *this->_bin1_id_it;
+  const auto next_row = current_row + 1;
+
+  const auto offset1 = this->_index->get_offset_by_bin_id(current_row);
+  const auto offset2 = [&]() {
+    const auto offset = this->_index->get_offset_by_bin_id(next_row);
+    if (offset == 0) {
+      return offset;
+    }
+    return std::max(offset1, offset - 1);
+  }();
+
+  assert(offset1 <= offset2);
+  if (offset1 == offset2) {
+    return;
+  }
+
+  const auto &bin2_id_dset = this->_bin2_id_it.dataset();
+  this->_bin2_id_it = std::lower_bound(
+      bin2_id_dset.template make_iterator_at_offset<std::uint64_t>(offset1),
+      bin2_id_dset.template make_iterator_at_offset<std::uint64_t>(offset2), bin_id);
+
+  const auto &bin1_id_dset = this->_bin1_id_it.dataset();
+  const auto &count_dset = this->_count_it.dataset();
+  const auto offset = this->_bin2_id_it.h5_offset();
+
+  this->_bin1_id_it = bin1_id_dset.template make_iterator_at_offset<std::uint64_t>(offset);
+  this->_count_it = count_dset.template make_iterator_at_offset<N>(offset);
+
+  assert(*this->_bin1_id_it == current_row);
+  assert(this->_bin2_id_it <= this->_bin2_id_last);
+}
+
+template <class N>
+inline void PixelSelector<N>::iterator::jump(std::uint64_t bin1_id, std::uint64_t bin2_id) {
+  assert(bin1_id <= bin2_id);
+
+  this->jump_to_row(bin1_id);
+  if (bin2_id != bin1_id) {
+    this->jump_to_col(bin2_id);
+  }
 }
 
 }  // namespace coolerpp

--- a/src/pixel_selector_impl.hpp
+++ b/src/pixel_selector_impl.hpp
@@ -213,6 +213,10 @@ inline PixelSelector<N>::iterator::iterator(std::shared_ptr<const Index> index,
   _bin2_id_last = it._bin2_id_last;
   assert(_bin2_id_it <= _bin2_id_last);
 
+  if (_bin2_id_it.h5_offset() == pixels_bin2_id.size()) {
+    return;
+  }
+
   // Now that last it is set, we can call jump_to_col() to seek to the first pixel actually
   // overlapping the query. Calling jump_to_next_overlap() is required to deal with rows that are
   // not empty, but that have no pixels overlapping the query
@@ -273,12 +277,16 @@ inline auto PixelSelector<N>::iterator::at_end(std::shared_ptr<const Index> inde
 
     it._count_it = pixels_count.make_iterator_at_offset<N>(offset);
 
+    if (offset == pixels_bin2_id.size()) {
+      return it;
+    }
+
     // Jump to the first column overlapping the query
     it.jump_to_col(it._coord2->bin1_id());
 
     // If discard() returns true, it means that the row corresponding to bin1_id does not contain
     // any pixel overlapping the query, so we keep looking backwards
-  } while (bin1_id-- != 0 && it.discard());
+  } while (bin1_id-- > it._coord1->bin1_id() && it.discard());
 
   // Now that we know the row pointed by it contains at least one pixel overlapping the query, jump
   // to the last column overlapping the query

--- a/src/pixel_selector_impl.hpp
+++ b/src/pixel_selector_impl.hpp
@@ -18,9 +18,9 @@ template <class N>
 inline PixelSelector<N>::PixelSelector(std::shared_ptr<const Index> index,
                                        const Dataset &pixels_bin1_id, const Dataset &pixels_bin2_id,
                                        const Dataset &pixels_count,
-                                       std::shared_ptr<PixelCoordinates> coords) noexcept
+                                       const std::shared_ptr<PixelCoordinates> &coords) noexcept
     : PixelSelector(std::move(index), pixels_bin1_id, pixels_bin2_id, pixels_count, coords,
-                    std::move(coords)) {}
+                    coords) {}
 
 template <class N>
 inline PixelSelector<N>::PixelSelector(std::shared_ptr<const Index> index,

--- a/src/pixel_selector_impl.hpp
+++ b/src/pixel_selector_impl.hpp
@@ -390,10 +390,10 @@ inline void PixelSelector<N>::iterator::jump_to_col(std::uint64_t bin_id) {
   const auto current_row = *this->_bin1_id_it;
   const auto next_row = current_row + 1;
 
-  const auto current_offset = this->h5_offset();
+  const auto current_offset = conditional_static_cast<std::uint64_t>(this->h5_offset());
   const auto current_row_offset = this->_index->get_offset_by_bin_id(current_row);
   const auto next_row_offset = this->_index->get_offset_by_bin_id(next_row);
-  const auto end_offset = this->_bin2_id_last.h5_offset();
+  const auto end_offset = conditional_static_cast<std::uint64_t>(this->_bin2_id_last.h5_offset());
 
   if (current_offset == next_row_offset) {
     return;  // Row is empty

--- a/test/units/cooler_test.cpp
+++ b/test/units/cooler_test.cpp
@@ -148,8 +148,8 @@ TEST_CASE("Coolerpp: file ctors", "[cooler][short]") {
       f = File::create_new_cooler(path.string(), chroms, bin_size, true);
       for (std::uint32_t pos1 = 0; pos1 < chroms.at("chr1").size; pos1 += bin_size) {
         for (std::uint32_t pos2 = pos1; pos2 < chroms.at("chr1").size; pos2 += bin_size) {
-          pixels.emplace_back(
-              PixelT{{f.bins(), "chr1", pos1, pos2}, static_cast<std::int32_t>(pixels.size() + 1)});
+          pixels.emplace_back(PixelT{{f.bins_ptr(), "chr1", pos1, pos2},
+                                     static_cast<std::int32_t>(pixels.size() + 1)});
         }
       }
       f.append_pixels(pixels.begin(), pixels.end(), true);

--- a/test/units/index_test.cpp
+++ b/test/units/index_test.cpp
@@ -20,7 +20,8 @@ namespace coolerpp::test::index {
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEST_CASE("Index: ctor", "[index][short]") {
   constexpr std::uint32_t bin_size = 100;
-  const BinTableLazy bins{{Chromosome{"chr1", 10001}, Chromosome{"chr2", 5000}}, bin_size};
+  const auto bins = std::make_shared<const BinTableLazy>(
+      ChromosomeSet{Chromosome{"chr1", 10001}, Chromosome{"chr2", 5000}}, bin_size);
 
   const Index idx(bins);
 
@@ -41,7 +42,8 @@ TEST_CASE("Index: ctor", "[index][short]") {
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEST_CASE("Index: offset setters and getters", "[index][short]") {
   constexpr std::uint32_t bin_size = 10;
-  const BinTableLazy bins{{Chromosome{"chr1", 100}}, bin_size};
+  const auto bins =
+      std::make_shared<const BinTableLazy>(ChromosomeSet{Chromosome{"chr1", 100}}, bin_size);
 
   constexpr auto fill_value = std::numeric_limits<std::uint64_t>::max();
 
@@ -95,7 +97,8 @@ TEST_CASE("Index: offset setters and getters", "[index][short]") {
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEST_CASE("Index: iterator", "[index][short]") {
   constexpr std::uint32_t bin_size = 1000;
-  const BinTableLazy bins{{Chromosome{"chr1", 10001}, Chromosome{"chr2", 5000}}, bin_size};
+  const auto bins = std::make_shared<const BinTableLazy>(
+      ChromosomeSet{Chromosome{"chr1", 10001}, Chromosome{"chr2", 5000}}, bin_size);
 
   // Assume there are 10 pixels per row
   constexpr std::array<std::size_t, 11> chr1_offsets{0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100};
@@ -128,7 +131,8 @@ TEST_CASE("Index: iterator", "[index][short]") {
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEST_CASE("Index: validation", "[index][short]") {
   constexpr std::uint32_t bin_size = 1000;
-  const BinTableLazy bins{{Chromosome{"chr1", 10001}, Chromosome{"chr2", 5000}}, bin_size};
+  const auto bins = std::make_shared<const BinTableLazy>(
+      ChromosomeSet{Chromosome{"chr1", 10001}, Chromosome{"chr2", 5000}}, bin_size);
 
   // Assume there are 10 pixels per row
   constexpr std::array<std::size_t, 11> chr1_offsets{0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100};
@@ -165,7 +169,8 @@ TEST_CASE("Index: validation", "[index][short]") {
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 TEST_CASE("Index: compute chromosome offsets", "[index][short]") {
   constexpr std::uint32_t bin_size = 1000;
-  const BinTableLazy bins{{Chromosome{"chr1", 10001}, Chromosome{"chr2", 5000}}, bin_size};
+  const auto bins = std::make_shared<const BinTableLazy>(
+      ChromosomeSet{Chromosome{"chr1", 10001}, Chromosome{"chr2", 5000}}, bin_size);
 
   // Assume there are 10 pixels per row
   constexpr std::array<std::size_t, 11> chr1_offsets{10, 20, 30, 40, 50, 60, 70, 80, 90, 100};
@@ -182,7 +187,7 @@ TEST_CASE("Index: compute chromosome offsets", "[index][short]") {
   }
 
   const auto chrom_offsets = idx.compute_chrom_offsets();
-  REQUIRE(chrom_offsets.size() == bins.num_chromosomes() + 1);
+  REQUIRE(chrom_offsets.size() == bins->num_chromosomes() + 1);
 
   CHECK(chrom_offsets[0] == 0);
   CHECK(chrom_offsets[1] == chr1_offsets.size());

--- a/test/units/pixel_selector_test.cpp
+++ b/test/units/pixel_selector_test.cpp
@@ -32,7 +32,7 @@ static std::size_t generate_test_data(const std::filesystem::path& path,
   N n = 0;
   for (std::uint64_t i = 0; i < num_bins; ++i) {
     for (std::uint64_t j = i; j < num_bins; ++j) {
-      pixels.emplace_back(Pixel<N>{PixelCoordinates{f.bins(), i, j}, n++});
+      pixels.emplace_back(Pixel<N>{PixelCoordinates{f.bins_ptr(), i, j}, n++});
     }
   }
   f.append_pixels(pixels.begin(), pixels.end());

--- a/test/units/pixel_selector_test.cpp
+++ b/test/units/pixel_selector_test.cpp
@@ -103,7 +103,7 @@ TEST_CASE("Pixel selector: 1D queries", "[pixel_selector][short]") {
 
     const auto sum = std::accumulate(
         selector.begin(), selector.end(), T(0),
-        [&](T accumulator, const Pixel<T> pixel) { return accumulator + pixel.count; });
+        [&](T accumulator, const Pixel<T>& pixel) { return accumulator + pixel.count; });
 
     CHECK(sum == 11852659);
   }
@@ -142,7 +142,7 @@ TEST_CASE("Pixel selector: 1D queries", "[pixel_selector][short]") {
     CHECK(std::distance(selector.begin(), selector.end()) == 5050);
     const auto sum = std::accumulate(
         selector.begin(), selector.end(), T(0),
-        [&](T accumulator, const Pixel<T> pixel) { return accumulator + pixel.count; });
+        [&](T accumulator, const Pixel<T>& pixel) { return accumulator + pixel.count; });
     CHECK(sum == 12748725);
   }
 

--- a/test/units/pixel_selector_test.cpp
+++ b/test/units/pixel_selector_test.cpp
@@ -54,8 +54,9 @@ TEST_CASE("Pixel selector: query", "[pixel_selector][short]") {
   REQUIRE(expected_pixels.size() == expected_nnz);
   SECTION("query overlaps chrom start") {
     auto selector = f.fetch<T>("chr1:0-20");
-    std::vector<Pixel<T>> pixels(selector.begin(), selector.end());
-    REQUIRE(std::distance(selector.begin(), selector.end()) == 3);
+    const std::vector<Pixel<T>> pixels(selector.begin(), selector.end());
+    REQUIRE(pixels.size() == 3);
+
     CHECK(pixels[0].count == 0);
     CHECK(pixels[1].count == 1);
     CHECK(pixels[2].count == 100);
@@ -63,9 +64,9 @@ TEST_CASE("Pixel selector: query", "[pixel_selector][short]") {
 
   SECTION("query overlaps chrom end") {
     auto selector = f.fetch<T>("chr1:980-1000");
-    std::vector<Pixel<T>> pixels(selector.begin(), selector.end());
-    REQUIRE(std::distance(selector.begin(), selector.end()) == 3);
-    pixels = std::vector<Pixel<T>>(selector.begin(), selector.end());
+    const std::vector<Pixel<T>> pixels(selector.begin(), selector.end());
+    REQUIRE(pixels.size() == 3);
+
     CHECK(pixels[0].count == 5047);
     CHECK(pixels[1].count == 5048);
     CHECK(pixels[2].count == 5049);
@@ -73,9 +74,9 @@ TEST_CASE("Pixel selector: query", "[pixel_selector][short]") {
 
   SECTION("query does not overlap chrom boundaries") {
     auto selector = f.fetch<T>("chr1:750-780");
-    std::vector<Pixel<T>> pixels(selector.begin(), selector.end());
-    REQUIRE(std::distance(selector.begin(), selector.end()) == 6);
-    pixels = std::vector<Pixel<T>>(selector.begin(), selector.end());
+    const std::vector<Pixel<T>> pixels(selector.begin(), selector.end());
+    REQUIRE(pixels.size() == 6);
+
     CHECK(pixels[0].count == 4725);
     CHECK(pixels[1].count == 4726);
     CHECK(pixels[2].count == 4727);
@@ -86,9 +87,9 @@ TEST_CASE("Pixel selector: query", "[pixel_selector][short]") {
 
   SECTION("query does not line up with bins") {
     auto selector = f.fetch<T>("chr1:901-927");
-    std::vector<Pixel<T>> pixels(selector.begin(), selector.end());
-    REQUIRE(std::distance(selector.begin(), selector.end()) == 6);
-    pixels = std::vector<Pixel<T>>(selector.begin(), selector.end());
+    const std::vector<Pixel<T>> pixels(selector.begin(), selector.end());
+    REQUIRE(pixels.size() == 6);
+
     CHECK(pixels[0].count == 4995);
     CHECK(pixels[1].count == 4996);
     CHECK(pixels[2].count == 4997);
@@ -106,17 +107,6 @@ TEST_CASE("Pixel selector: query", "[pixel_selector][short]") {
         [&](T accumulator, const Pixel<T> pixel) { return accumulator + pixel.count; });
 
     CHECK(sum == 11852659);
-  }
-
-  SECTION("empty query") {
-    auto selector = f.fetch<T>("chr1:0-0");
-    CHECK(selector.begin() == selector.end());
-
-    selector = f.fetch<T>("chr1:100-100");
-    CHECK(selector.begin() == selector.end());
-
-    selector = f.fetch<T>("chr1:1000-1000");
-    CHECK(selector.begin() == selector.end());
   }
 
   SECTION("query spans 1 bin") {
@@ -187,8 +177,12 @@ TEST_CASE("Pixel selector: query", "[pixel_selector][short]") {
     CHECK_THROWS_WITH(f.fetch<T>("chr1:0-4294967296"),
                       Catch::Matchers::ContainsSubstring("invalid end position"));
 
-    CHECK_THROWS_WITH(f.fetch<T>("chr1:10-5"), Catch::Matchers::ContainsSubstring(
-                                                   "start position is greater than end position"));
+    CHECK_THROWS_WITH(f.fetch<T>("chr1:0-0"),
+                      Catch::Matchers::ContainsSubstring(
+                          "end position should be greater than the start position"));
+    CHECK_THROWS_WITH(f.fetch<T>("chr1:10-5"),
+                      Catch::Matchers::ContainsSubstring(
+                          "end position should be greater than the start position"));
   }
 }
 

--- a/test/units/pixel_test.cpp
+++ b/test/units/pixel_test.cpp
@@ -18,7 +18,7 @@ TEST_CASE("Pixel", "[pixel][short]") {
                              Chromosome{"chr9", 138'394'717}, Chromosome{"chr11", 135'086'622},
                              Chromosome{"chr12", 133'275'309}};
   constexpr std::uint32_t bin_size = 1;
-  const BinTableLazy bins(chroms, bin_size);
+  const auto bins = std::make_shared<const BinTableLazy>(chroms, bin_size);
 
   auto P = [&](std::string_view chrom1, std::string_view chrom2, std::uint32_t pos1,
                std::uint32_t pos2, std::uint32_t count = 0) {

--- a/test/units/pixel_test.cpp
+++ b/test/units/pixel_test.cpp
@@ -17,7 +17,7 @@ TEST_CASE("Pixel", "[pixel][short]") {
                              Chromosome{"chr5", 181'538'259}, Chromosome{"chr6", 170'805'979},
                              Chromosome{"chr9", 138'394'717}, Chromosome{"chr11", 135'086'622},
                              Chromosome{"chr12", 133'275'309}};
-  constexpr std::uint32_t bin_size = 10;
+  constexpr std::uint32_t bin_size = 1;
   const BinTableLazy bins(chroms, bin_size);
 
   auto P = [&](std::string_view chrom1, std::string_view chrom2, std::uint32_t pos1,
@@ -26,7 +26,7 @@ TEST_CASE("Pixel", "[pixel][short]") {
   };
 
   SECTION("operator bool") {
-    CHECK(!PixelCoordinates{bins, (std::numeric_limits<std::uint32_t>::max)(), 0, 0});
+    CHECK(!PixelCoordinates{});
     CHECK(!!P("chr1", "chr1", 0, 10));
   }
 


### PR DESCRIPTION
Initial support for 2D queries.

For the time being, only queries overlapping matrix upper triangle are supported.