### PR TITLE
Add support for reading/writing cis attribute

### DIFF
--- a/src/coolerpp.cpp
+++ b/src/coolerpp.cpp
@@ -261,6 +261,7 @@ void File::write_standard_attributes(RootGroup &root_grp, const StandardAttribut
   Attribute::write(root_grp(), "nnz", *attributes.nnz);
   Attribute::write(root_grp(), "storage-mode", *attributes.storage_mode);
   std::visit([&](const auto sum) { Attribute::write(root_grp(), "sum", sum); }, attributes.sum);
+  std::visit([&](const auto cis) { Attribute::write(root_grp(), "cis", cis); }, attributes.cis);
 }
 
 auto File::open_datasets(const RootGroup &root_grp, std::string_view weight_dataset) -> DatasetMap {
@@ -314,9 +315,7 @@ auto File::read_standard_attributes(const RootGroup &root_grp, bool initialize_m
     }
   };
 
-  auto read_sum_optional = [&](bool missing_ok) {
-    constexpr std::string_view key = "sum";
-    auto &buff = attrs.sum;
+  auto read_sum_optional = [&](bool missing_ok, std::string_view key, StandardAttributes::SumVar& buff) {
     if (!Attribute::exists(root_grp(), key) && missing_ok) {
       return false;
     }
@@ -380,7 +379,8 @@ auto File::read_standard_attributes(const RootGroup &root_grp, bool initialize_m
   read_optional("nchroms", attrs.nchroms, missing_ok);
   read_optional("nnz", attrs.nnz, missing_ok);
 
-  read_sum_optional(missing_ok);
+  read_sum_optional(missing_ok, "sum", attrs.sum);
+  read_sum_optional(missing_ok, "cis", attrs.cis);
 
   return attrs;
 }

--- a/src/coolerpp.cpp
+++ b/src/coolerpp.cpp
@@ -260,8 +260,10 @@ void File::write_standard_attributes(RootGroup &root_grp, const StandardAttribut
   Attribute::write(root_grp(), "nchroms", *attributes.nchroms);
   Attribute::write(root_grp(), "nnz", *attributes.nnz);
   Attribute::write(root_grp(), "storage-mode", *attributes.storage_mode);
-  std::visit([&](const auto sum) { Attribute::write(root_grp(), "sum", sum); }, attributes.sum);
-  std::visit([&](const auto cis) { Attribute::write(root_grp(), "cis", cis); }, attributes.cis);
+  assert(attributes.sum.has_value());
+  assert(attributes.cis.has_value());
+  std::visit([&](const auto sum) { Attribute::write(root_grp(), "sum", sum); }, *attributes.sum);
+  std::visit([&](const auto cis) { Attribute::write(root_grp(), "cis", cis); }, *attributes.cis);
 }
 
 auto File::open_datasets(const RootGroup &root_grp, std::string_view weight_dataset) -> DatasetMap {
@@ -315,7 +317,7 @@ auto File::read_standard_attributes(const RootGroup &root_grp, bool initialize_m
     }
   };
 
-  auto read_sum_optional = [&](bool missing_ok, std::string_view key, StandardAttributes::SumVar& buff) {
+  auto read_sum_optional = [&](bool missing_ok, std::string_view key, auto& buff) {
     if (!Attribute::exists(root_grp(), key) && missing_ok) {
       return false;
     }
@@ -667,6 +669,8 @@ StandardAttributes StandardAttributes::init_empty() noexcept {
   attrs.nchroms.reset();
   attrs.metadata.reset();
   attrs.storage_mode.reset();
+  attrs.sum.reset();
+  attrs.cis.reset();
 
   return attrs;
 }

--- a/src/coolerpp_impl.hpp
+++ b/src/coolerpp_impl.hpp
@@ -310,11 +310,14 @@ inline StandardAttributes StandardAttributes::init(std::uint32_t bin_size_) {
   attrs.bin_size = bin_size_;
   if constexpr (std::is_floating_point_v<PixelT>) {
     attrs.sum = 0.0;
+    attrs.cis = 0.0;
   } else if constexpr (std::is_signed_v<PixelT>) {
     attrs.sum = std::int64_t(0);
+    attrs.cis = std::int64_t(0);
   } else {
     assert(std::is_unsigned_v<PixelT>);
     attrs.sum = std::uint64_t(0);
+    attrs.cis = std::uint64_t(0);
   }
   return attrs;
 }
@@ -397,14 +400,19 @@ inline void File::append_pixels(PixelIt first_pixel, PixelIt last_pixel, bool va
   });
 
   T sum = 0;
+  T cis_sum = 0;
   this->dataset("pixels/count").append(first_pixel, last_pixel, [&](const Pixel<T> &pixel) {
     sum += pixel.count;
+    if (pixel.coords.chrom1_id() == pixel.coords.chrom2_id()) {
+      cis_sum += pixel.count;
+    }
     return pixel.count;
   });
 
   this->_attrs.nnz = this->dataset("pixels/bin1_id").size();
 
   this->update_pixel_sum(sum);
+  this->update_pixel_sum<T, true>(cis_sum);
 }
 
 template <class N>
@@ -496,16 +504,17 @@ inline PixelSelector<N> File::fetch(PixelCoordinates coord1, PixelCoordinates co
   // clang-format on
 }
 
-template <class N>
+template <class N, bool cis>
 inline void File::update_pixel_sum(N partial_sum) {
   static_assert(std::is_arithmetic_v<N>);
+
+  auto &buff = cis ? this->_attrs.cis : this->_attrs.sum;
   if constexpr (std::is_floating_point_v<N>) {
-    std::get<double>(this->_attrs.sum) += conditional_static_cast<double>(partial_sum);
+    std::get<double>(buff) += conditional_static_cast<double>(partial_sum);
   } else if constexpr (std::is_signed_v<N>) {
-    std::get<std::int64_t>(this->_attrs.sum) += conditional_static_cast<std::int64_t>(partial_sum);
+    std::get<std::int64_t>(buff) += conditional_static_cast<std::int64_t>(partial_sum);
   } else {
-    std::get<std::uint64_t>(this->_attrs.sum) +=
-        conditional_static_cast<std::uint64_t>(partial_sum);
+    std::get<std::uint64_t>(buff) += conditional_static_cast<std::uint64_t>(partial_sum);
   }
 }
 

--- a/src/coolerpp_impl.hpp
+++ b/src/coolerpp_impl.hpp
@@ -524,7 +524,7 @@ inline void File::validate_pixel_type() const noexcept {
   static_assert(std::is_arithmetic_v<PixelT>);
 
   auto assert_holds_alternative = [](const auto &buff, [[maybe_unused]] auto alt) {
-    using T = decltype(alt);
+   using T [[maybe_unused]] = decltype(alt);
     if (buff.has_value()) {
       assert(std::holds_alternative<T>(*buff));
     }

--- a/src/include/coolerpp/coolerpp.hpp
+++ b/src/include/coolerpp/coolerpp.hpp
@@ -58,8 +58,8 @@ struct StandardAttributes {
   std::optional<std::uint32_t> nchroms{0};
   std::optional<std::uint64_t> nnz{0};
   using SumVar = std::variant<double, std::int64_t, std::uint64_t>;
-  SumVar sum{std::int64_t(0)};
-  SumVar cis{std::int64_t(0)};
+  std::optional<SumVar> sum{std::int64_t(0)};
+  std::optional<SumVar> cis{std::int64_t(0)};
 
   template <class PixelT = DefaultPixelT, class = std::enable_if_t<std::is_arithmetic_v<PixelT>>>
   [[nodiscard]] static StandardAttributes init(std::uint32_t bin_size_);

--- a/src/include/coolerpp/coolerpp.hpp
+++ b/src/include/coolerpp/coolerpp.hpp
@@ -59,6 +59,7 @@ struct StandardAttributes {
   std::optional<std::uint64_t> nnz{0};
   using SumVar = std::variant<double, std::int64_t, std::uint64_t>;
   SumVar sum{std::int64_t(0)};
+  SumVar cis{std::int64_t(0)};
 
   template <class PixelT = DefaultPixelT, class = std::enable_if_t<std::is_arithmetic_v<PixelT>>>
   [[nodiscard]] static StandardAttributes init(std::uint32_t bin_size_);
@@ -285,7 +286,7 @@ class File {
 
   [[nodiscard]] auto get_last_bin_written() const -> Bin;
 
-  template <class N>
+  template <class N, bool cis = false>
   void update_pixel_sum(N partial_sum);
 
   template <class PixelT>

--- a/test/units/cooler_test.cpp
+++ b/test/units/cooler_test.cpp
@@ -332,7 +332,11 @@ TEST_CASE("Coolerpp: read attributes", "[cooler][short]") {
     CHECK(attrs.nchroms == 20);
     CHECK(attrs.nnz == 107041);
     CHECK(attrs.storage_mode == "symmetric-upper");
-    std::visit([](auto& sum) { CHECK(sum == 395465); }, attrs.sum);
+    CHECK(attrs.sum.has_value());
+    if (attrs.sum.has_value()) {
+      std::visit([](auto& sum) { CHECK(sum == 395465); }, *attrs.sum);
+    }
+    CHECK(!attrs.cis.has_value());
   }
 }
 
@@ -464,7 +468,7 @@ TEST_CASE("Coolerpp: read/write pixels", "[cooler][long]") {
     CHECK(f1.attributes().nbins == f2.attributes().nbins);
     CHECK(f1.attributes().nnz == f2.attributes().nnz);
     CHECK(f1.attributes().sum == f2.attributes().sum);
-    CHECK(f2.attributes().cis == StandardAttributes::SumVar(329276));
+    CHECK(f2.attributes().cis == StandardAttributes::SumVar(std::int64_t(329276)));
   }
 }
 

--- a/test/units/cooler_test.cpp
+++ b/test/units/cooler_test.cpp
@@ -387,13 +387,12 @@ TEST_CASE("Coolerpp: read/write pixels", "[cooler][long]") {
   auto path1 = datadir / "cooler_test_file.cool";
   auto path2 = testdir() / "cooler_test_read_write_pixels.cool";
 
+  using T = std::int32_t;
   auto f1 = File::open_read_only(path1.string());
   {
-    auto f2 = File::create_new_cooler<std::uint32_t>(path2.string(), f1.chromosomes(),
-                                                     f1.bin_size(), true);
+    auto f2 = File::create_new_cooler<T>(path2.string(), f1.chromosomes(), f1.bin_size(), true);
 
-    const std::vector<Pixel<std::uint32_t>> expected(f1.begin<std::uint32_t>(),
-                                                     f1.end<std::uint32_t>());
+    const std::vector<Pixel<T>> expected(f1.begin<T>(), f1.end<T>());
     REQUIRE(expected.size() == 107041);
 
     std::random_device rd;
@@ -402,6 +401,7 @@ TEST_CASE("Coolerpp: read/write pixels", "[cooler][long]") {
     auto pixel_it = expected.begin();
     do {
       const auto diff = std::distance(pixel_it, expected.end());
+      // Write pixels in chunks of random size
       const auto offset =
           (std::min)(diff, std::uniform_int_distribution<std::ptrdiff_t>{500, 5000}(rand_eng));
       // fmt::print(stderr, FMT_STRING("Processing {}-{} out of {}\n"),
@@ -441,15 +441,30 @@ TEST_CASE("Coolerpp: read/write pixels", "[cooler][long]") {
   }
 
   SECTION("compare pixels") {
-    const std::vector<Pixel<std::uint32_t>> expected_pixels(f1.begin<std::uint32_t>(),
-                                                            f1.end<std::uint32_t>());
-    const std::vector<Pixel<std::uint32_t>> pixels(f2.begin<std::uint32_t>(),
-                                                   f2.end<std::uint32_t>());
+    const std::vector<Pixel<T>> expected_pixels(f1.begin<T>(), f1.end<T>());
+    const std::vector<Pixel<T>> pixels(f2.begin<T>(), f2.end<T>());
 
     REQUIRE(expected_pixels.size() == pixels.size());
     for (std::size_t i = 0; i < pixels.size(); ++i) {
       CHECK(pixels[i] == expected_pixels[i]);
     }
+  }
+
+  SECTION("compare attributes") {
+    CHECK(f1.attributes().bin_size == f2.attributes().bin_size);
+    CHECK(f1.attributes().bin_type == f2.attributes().bin_type);
+    CHECK(f1.attributes().format == f2.attributes().format);
+    CHECK(f1.attributes().storage_mode == f2.attributes().storage_mode);
+    CHECK(f1.attributes().creation_date != f2.attributes().creation_date);
+    CHECK(f1.attributes().generated_by != f2.attributes().generated_by);
+    CHECK(f1.attributes().assembly == f2.attributes().assembly);
+    CHECK(f2.attributes().metadata == "{}");
+    // Test file is still using https://github.com/mirnylab/cooler as format_url
+    // CHECK(f1.attributes().format_url == f2.attributes().format_url);
+    CHECK(f1.attributes().nbins == f2.attributes().nbins);
+    CHECK(f1.attributes().nnz == f2.attributes().nnz);
+    CHECK(f1.attributes().sum == f2.attributes().sum);
+    CHECK(f2.attributes().cis == StandardAttributes::SumVar(329276));
   }
 }
 


### PR DESCRIPTION
This attribute stores the total number of cis iteractions, and is currently used by some libraries/tools (e.g. `cooltools random-sample`)