### PR TITLE
Enable dataset shuffling

### DIFF
--- a/src/dataset_impl.hpp
+++ b/src/dataset_impl.hpp
@@ -25,6 +25,7 @@ inline HighFive::DataSetCreateProps Dataset::generate_default_dset_create_props(
     std::uint_fast8_t compression_lvl, const std::size_t chunk_size) {
   assert(chunk_size != 0);
   HighFive::DataSetCreateProps props{};
+  props.add(HighFive::Shuffle());
   props.add(HighFive::Deflate(conditional_static_cast<std::uint32_t>(compression_lvl)));
   props.add(HighFive::Chunking(chunk_size / sizeof(std::int32_t)));
   return props;


### PR DESCRIPTION
Enabling shuffling seems a no-brainer, as it significantly increase write throughput while reducing file size without affecting read performance.

|                | coolerpp wo/ shuffling | coolerpp w/ shuffling | cooler  |
|----------------|------------------------|-----------------------|---------|
| time (s)       | 2060.428               | 1417.695              | 3503.92 |
| size (GBs)     | 4.1                    | 2.8                   | 3.5     |

<details>
<summary>Logs</summary>

```
Written 1646130512 pixels in 2060.428s!
        Command being timed: "./coolerpp_load test/data/chrom.sizes 1000 4DNFI9FVHJZQ.coolerpp.1000.cool"
        User time (seconds): 2022.75
        System time (seconds): 28.60
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 34:21.01
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1433812
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 247138
        Voluntary context switches: 114
        Involuntary context switches: 3487
        Swaps: 0
        File system inputs: 0
        File system outputs: 8482088
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

```
Written 1646130512 pixels in 1417.695s!
        Command being timed: "./coolerpp_load_shuffle test/data/chrom.sizes 1000 4DNFI9FVHJZQ.coolerpp.1000.cool"
        User time (seconds): 1383.89
        System time (seconds): 27.66
        Percent of CPU this job got: 99%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 23:38.27
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 1434044
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 271582
        Voluntary context switches: 294
        Involuntary context switches: 1964
        Swaps: 0
        File system inputs: 0
        File system outputs: 5789232
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

```
        Command being timed: "test/scripts/cooler_load.py test/data/chrom.sizes --bin-size 1000 - 4DNFI9FVHJZQ.cooler.1000.cool --force"
        User time (seconds): 3364.92
        System time (seconds): 61.62
        Percent of CPU this job got: 97%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 58:23.92
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 603200
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 486537
        Voluntary context switches: 939868
        Involuntary context switches: 4978
        Swaps: 0
        File system inputs: 0
        File system outputs: 7376440
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

</details>