### PR TITLE
Make integral attributes signed

### DIFF
--- a/src/coolerpp_impl.hpp
+++ b/src/coolerpp_impl.hpp
@@ -298,7 +298,7 @@ inline void File::update_pixel_sum(N partial_sum) {
   assert(buff.has_value());
   if constexpr (std::is_floating_point_v<N>) {
     std::get<double>(*buff) += conditional_static_cast<double>(partial_sum);
-  } else if constexpr (std::is_signed_v<N>) {
+  } else {
     assert(std::is_signed_v<N>);
     std::get<std::int64_t>(*buff) += conditional_static_cast<std::int64_t>(partial_sum);
   }

--- a/src/coolerpp_impl.hpp
+++ b/src/coolerpp_impl.hpp
@@ -84,10 +84,10 @@ inline File::File(std::string_view uri, unsigned mode, bool validate)
       _bins(std::make_shared<BinTable>(
           import_chroms(_datasets.at("chroms/name"), _datasets.at("chroms/length"), false),
           this->bin_size())),
-      _index(std::make_shared<Index>(import_indexes(_datasets.at("indexes/chrom_offset"),
-                                                    _datasets.at("indexes/bin1_offset"),
-                                                    // NOLINTNEXTLINE
-                                                    chromosomes(), _bins, *_attrs.nnz, false))) {
+      _index(std::make_shared<Index>(
+          import_indexes(_datasets.at("indexes/chrom_offset"), _datasets.at("indexes/bin1_offset"),
+                         // NOLINTNEXTLINE
+                         chromosomes(), _bins, static_cast<std::uint64_t>(*_attrs.nnz), false))) {
   assert(mode == HighFive::File::ReadOnly || mode == HighFive::File::ReadWrite);
   if (validate) {
     this->validate_bins();
@@ -221,7 +221,7 @@ inline void File::finalize() {
     this->write_bin_table();
 
     assert(_attrs.nnz.has_value());
-    _index->nnz() = *_attrs.nnz;
+    _index->nnz() = static_cast<std::uint64_t>(*_attrs.nnz);
     this->write_indexes();
     this->write_attributes();
 
@@ -299,9 +299,8 @@ inline void File::update_pixel_sum(N partial_sum) {
   if constexpr (std::is_floating_point_v<N>) {
     std::get<double>(*buff) += conditional_static_cast<double>(partial_sum);
   } else if constexpr (std::is_signed_v<N>) {
+    assert(std::is_signed_v<N>);
     std::get<std::int64_t>(*buff) += conditional_static_cast<std::int64_t>(partial_sum);
-  } else {
-    std::get<std::uint64_t>(*buff) += conditional_static_cast<std::uint64_t>(partial_sum);
   }
 }
 

--- a/src/coolerpp_impl.hpp
+++ b/src/coolerpp_impl.hpp
@@ -299,7 +299,7 @@ inline void File::update_pixel_sum(N partial_sum) {
   if constexpr (std::is_floating_point_v<N>) {
     std::get<double>(*buff) += conditional_static_cast<double>(partial_sum);
   } else {
-    assert(std::is_signed_v<N>);
+    assert(std::is_integral_v<N>);
     std::get<std::int64_t>(*buff) += conditional_static_cast<std::int64_t>(partial_sum);
   }
 }

--- a/src/coolerpp_read_impl.hpp
+++ b/src/coolerpp_read_impl.hpp
@@ -210,11 +210,7 @@ inline auto File::read_standard_attributes(const RootGroup &root_grp, bool initi
       std::visit(
           [&](auto sum) {
             using T = remove_cvref_t<decltype(sum)>;
-            if constexpr (std::is_unsigned_v<T>) {
-              buff = conditional_static_cast<std::uint64_t>(sum);
-              return;
-            }
-            if constexpr (std::is_signed_v<T>) {
+            if constexpr (std::is_integral_v<T>) {
               buff = conditional_static_cast<std::int64_t>(sum);
               return;
             }

--- a/src/coolerpp_standard_attr_impl.hpp
+++ b/src/coolerpp_standard_attr_impl.hpp
@@ -17,13 +17,10 @@ inline StandardAttributes StandardAttributes::init(std::uint32_t bin_size_) {
   if constexpr (std::is_floating_point_v<PixelT>) {
     attrs.sum = 0.0;
     attrs.cis = 0.0;
-  } else if constexpr (std::is_signed_v<PixelT>) {
+  }
+  if constexpr (std::is_integral_v<PixelT>) {
     attrs.sum = std::int64_t(0);
     attrs.cis = std::int64_t(0);
-  } else {
-    assert(std::is_unsigned_v<PixelT>);
-    attrs.sum = std::uint64_t(0);
-    attrs.cis = std::uint64_t(0);
   }
   return attrs;
 }

--- a/src/coolerpp_validation_impl.hpp
+++ b/src/coolerpp_validation_impl.hpp
@@ -156,14 +156,10 @@ inline void File::validate_pixel_type() const noexcept {
     assert(this->has_float_pixels());
     assert_holds_alternative(this->_attrs.sum, double{});
     assert_holds_alternative(this->_attrs.cis, double{});
-  } else if constexpr (std::is_signed_v<PixelT>) {
-    assert(this->has_signed_pixels());
+  } else {
+    assert(this->has_unsigned_pixels() || this->has_signed_pixels());
     assert_holds_alternative(this->_attrs.sum, std::int64_t{});
     assert_holds_alternative(this->_attrs.cis, std::int64_t{});
-  } else {
-    assert(this->has_unsigned_pixels());
-    assert_holds_alternative(this->_attrs.sum, std::uint64_t{});
-    assert_holds_alternative(this->_attrs.cis, std::uint64_t{});
   }
 }
 

--- a/src/coolerpp_validation_impl.hpp
+++ b/src/coolerpp_validation_impl.hpp
@@ -157,7 +157,7 @@ inline void File::validate_pixel_type() const noexcept {
     assert_holds_alternative(this->_attrs.sum, double{});
     assert_holds_alternative(this->_attrs.cis, double{});
   } else {
-    assert(this->has_unsigned_pixels() || this->has_signed_pixels());
+    assert(this->has_integral_pixels());
     assert_holds_alternative(this->_attrs.sum, std::int64_t{});
     assert_holds_alternative(this->_attrs.cis, std::int64_t{});
   }

--- a/src/coolerpp_write_impl.hpp
+++ b/src/coolerpp_write_impl.hpp
@@ -294,7 +294,7 @@ inline void File::update_indexes(PixelIt first_pixel, PixelIt last_pixel) {
 
   const auto last_bin_written = this->get_last_bin_written();
 
-  auto nnz = *this->_attrs.nnz;
+  auto nnz = static_cast<std::uint64_t>(*this->_attrs.nnz);
   PixelCoordinates first_pixel_in_row{this->_bins, last_bin_written.chrom.name,
                                       last_bin_written.start, last_bin_written.start};
 
@@ -309,7 +309,7 @@ inline void File::update_indexes(PixelIt first_pixel, PixelIt last_pixel) {
 
 inline void File::write_indexes() {
   assert(this->_attrs.nnz.has_value());
-  this->index().finalize(*this->_attrs.nnz);
+  this->index().finalize(static_cast<std::uint64_t>(*this->_attrs.nnz));
   File::write_indexes(this->dataset("indexes/chrom_offset"), this->dataset("indexes/bin1_offset"),
                       this->index());
 }

--- a/src/include/coolerpp/coolerpp.hpp
+++ b/src/include/coolerpp/coolerpp.hpp
@@ -54,10 +54,10 @@ struct StandardAttributes {
 
   // Optional but common
   std::optional<std::string> format_url{"https://github.com/open2c/cooler"};
-  std::optional<std::uint64_t> nbins{0};
-  std::optional<std::uint32_t> nchroms{0};
-  std::optional<std::uint64_t> nnz{0};
-  using SumVar = std::variant<double, std::int64_t, std::uint64_t>;
+  std::optional<std::int64_t> nbins{0};
+  std::optional<std::int32_t> nchroms{0};
+  std::optional<std::int64_t> nnz{0};
+  using SumVar = std::variant<double, std::int64_t>;
   std::optional<SumVar> sum{std::int64_t(0)};
   std::optional<SumVar> cis{std::int64_t(0)};
 


### PR DESCRIPTION
Cooler does not yet properly handle uint attributes.
See https://github.com/open2c/cooler/pull/323 for more details