### PR TITLE
Explicitly link to HDF5

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@
 find_package(FastFloat CONFIG REQUIRED)
 find_package(Filesystem REQUIRED)
 find_package(fmt CONFIG REQUIRED)
+find_package(HDF5 CONFIG REQUIRED)
 find_package(HighFive CONFIG REQUIRED)
 find_package(tsl-hopscotch-map CONFIG REQUIRED)
 find_package(tsl-ordered-map CONFIG REQUIRED)
@@ -47,6 +48,7 @@ target_link_system_libraries(
   INTERFACE
   FastFloat::fast_float
   fmt::fmt
+  HDF5::HDF5
   HighFive
   tsl::hopscotch_map
   tsl::ordered_map


### PR DESCRIPTION
src/dataset_write_impl.hpp is including some hdf5 headers, so we have to explicitly link to HDF5