### PR TITLE
Various small bugfixes

### DIFF
--- a/src/chromosome_impl.hpp
+++ b/src/chromosome_impl.hpp
@@ -20,7 +20,9 @@
 namespace coolerpp {
 
 inline Chromosome::Chromosome(std::string name_, std::uint32_t size_) noexcept
-    : name(std::move(name_)), size(size_) {}
+    : name(std::move(name_)), size(size_) {
+  assert(size != 0);
+}
 
 inline bool Chromosome::operator<(const Chromosome& other) const noexcept {
   return this->name < other.name;

--- a/src/coolerpp_read_impl.hpp
+++ b/src/coolerpp_read_impl.hpp
@@ -112,8 +112,8 @@ inline PixelSelector<N> File::fetch(std::string_view chrom1, std::uint32_t start
                           this->dataset("pixels/bin1_id"),
                           this->dataset("pixels/bin2_id"),
                           this->dataset("pixels/count"),
-                          PixelCoordinates{this->_bins, chrom1, start1, end1},
-                          PixelCoordinates{this->_bins, chrom2, start2, end2});
+                          PixelCoordinates{this->_bins, chrom1, start1, end1 - std::min(1U, end1)},
+                          PixelCoordinates{this->_bins, chrom2, start2, end2 - std::min(1U, end2)});
   // clang-format on
 }
 

--- a/src/include/coolerpp/coolerpp.hpp
+++ b/src/include/coolerpp/coolerpp.hpp
@@ -192,8 +192,6 @@ class File {
   template <class N>
   [[nodiscard]] PixelSelector<N> fetch(std::string_view chrom, std::uint32_t start,
                                        std::uint32_t end) const;
-  template <class N>
-  [[nodiscard]] PixelSelector<N> fetch(PixelCoordinates query) const;
 
   template <class N>
   [[nodiscard]] PixelSelector<N> fetch(std::string_view range1, std::string_view range2) const;
@@ -201,8 +199,6 @@ class File {
   [[nodiscard]] PixelSelector<N> fetch(std::string_view chrom1, std::uint32_t start1,
                                        std::uint32_t end1, std::string_view chrom2,
                                        std::uint32_t start2, std::uint32_t end2) const;
-  template <class N>
-  [[nodiscard]] PixelSelector<N> fetch(PixelCoordinates coord1, PixelCoordinates coord2) const;
 
   void flush();
 
@@ -291,6 +287,12 @@ class File {
 
   template <class PixelT>
   void validate_pixel_type() const noexcept;
+
+  // IMPORTANT: the private fetch() methods interpret queries as open-open
+  template <class N>
+  [[nodiscard]] PixelSelector<N> fetch(PixelCoordinates query) const;
+  template <class N>
+  [[nodiscard]] PixelSelector<N> fetch(PixelCoordinates coord1, PixelCoordinates coord2) const;
 };
 
 }  // namespace coolerpp

--- a/src/include/coolerpp/pixel_selector.hpp
+++ b/src/include/coolerpp/pixel_selector.hpp
@@ -54,6 +54,9 @@ class PixelSelector {
                 const Dataset &pixels_bin2_id, const Dataset &pixels_count, PixelCoordinates coord1,
                 PixelCoordinates coord2) noexcept;
 
+  [[nodiscard]] bool operator==(const PixelSelector<N>& other) const noexcept;
+  [[nodiscard]] bool operator!=(const PixelSelector<N>& other) const noexcept;
+
   [[nodiscard]] auto begin() const -> iterator;
   [[nodiscard]] auto end() const -> iterator;
 

--- a/src/pixel_selector_impl.hpp
+++ b/src/pixel_selector_impl.hpp
@@ -503,7 +503,7 @@ inline void PixelSelector<N>::iterator::jump_to_next_overlap() {
     // There's no more data to be read, as we're past the last column overlapping the query,
     // and the next row does not overlap the query
     if (this->_bin2_id_it >= this->_bin2_id_last || next_row > this->_coord1->bin2_id()) {
-      assert(col > this->_coord2->bin2_id());
+      // assert(col > this->_coord2->bin2_id());  // This is not always true for trans queries
       this->jump_at_end();
       return;
     }

--- a/src/pixel_selector_impl.hpp
+++ b/src/pixel_selector_impl.hpp
@@ -62,6 +62,16 @@ inline PixelSelector<N>::PixelSelector(std::shared_ptr<const Index> index,
                     std::make_shared<PixelCoordinates>(std::move(coord2))) {}
 
 template <class N>
+inline bool PixelSelector<N>::operator==(const PixelSelector<N> &other) const noexcept {
+  return this->begin() == other.begin() && this->end() == other.end();
+}
+
+template <class N>
+inline bool PixelSelector<N>::operator!=(const PixelSelector<N> &other) const noexcept {
+  return !(*this == other);
+}
+
+template <class N>
 inline auto PixelSelector<N>::begin() const -> iterator {
   return this->cbegin();
 }

--- a/test/units/bin_table_test.cpp
+++ b/test/units/bin_table_test.cpp
@@ -39,7 +39,7 @@ TEST_CASE("BinTableLazy", "[bin-table][short]") {
     CHECK(table.at(1) == expected);
     CHECK(table.at("chr1") != expected);
 
-    CHECK_THROWS_AS(table.at(Chromosome{"chr5", 0}), std::out_of_range);
+    CHECK_THROWS_AS(table.at(Chromosome{"chr5", 1}), std::out_of_range);
     CHECK_THROWS_AS(table.at("a"), std::out_of_range);
     CHECK_THROWS_AS(table.at(10), std::out_of_range);
   }

--- a/test/units/pixel_selector_test.cpp
+++ b/test/units/pixel_selector_test.cpp
@@ -162,6 +162,15 @@ TEST_CASE("Pixel selector: 1D queries", "[pixel_selector][short]") {
     CHECK(sum == 334'290);
   }
 
+  SECTION("equality operator") {
+    CHECK(f.fetch<T>("chr1:0-1000") == f.fetch<T>("chr1:0-1000"));
+    CHECK(f.fetch<T>("chr1:10-1000") != f.fetch<T>("chr1:0-1000"));
+  }
+
+  SECTION("overloads return identical results") {
+    CHECK(f.fetch<T>("chr1:0-1000") == f.fetch<T>("chr1", 0, 1000));
+  }
+
   SECTION("invalid queries") {
     CHECK_THROWS_WITH(f.fetch<T>(""), Catch::Matchers::Equals("query is empty"));
     CHECK_THROWS_WITH(f.fetch<T>("chr3"), Catch::Matchers::ContainsSubstring("invalid chromosome"));
@@ -206,6 +215,11 @@ TEST_CASE("Pixel selector: 2D queries", "[pixel_selector][short]") {
   auto f = File::open_read_only(path.string());
 
   SECTION("cis") {
+    SECTION("overloads return identical results") {
+      CHECK(f.fetch<T>("1:5000000-5500000", "1:5000000-6500000") ==
+            f.fetch<T>("1", 5000000, 5500000, "1", 5000000, 6500000));
+    }
+
     SECTION("valid") {
       auto selector = f.fetch<T>("1:5000000-5500000", "1:5000000-6500000");
       const std::vector<Pixel<T>> pixels(selector.begin(), selector.end());
@@ -228,6 +242,10 @@ TEST_CASE("Pixel selector: 2D queries", "[pixel_selector][short]") {
   }
 
   SECTION("trans") {
+    SECTION("overloads return identical results") {
+      CHECK(f.fetch<T>("1:48000000-50000000", "4:30000000-35000000") ==
+            f.fetch<T>("1", 48000000, 50000000, "4", 30000000, 35000000));
+    }
     SECTION("valid") {
       auto selector = f.fetch<T>("1:48000000-50000000", "4:30000000-35000000");
       const std::vector<Pixel<T>> pixels(selector.begin(), selector.end());


### PR DESCRIPTION
- Assert chromosome size is non-zero
- Remove assertion from `PixelSelector<N>::iterator` (assertion doesn't always hold for trans queries)
- Add tests for all `File::fetch<>()` overloads