### PR TITLE
Performance optimization

### DIFF
--- a/src/include/coolerpp/bin_table.hpp
+++ b/src/include/coolerpp/bin_table.hpp
@@ -111,6 +111,7 @@ class BinTable {
   [[nodiscard]] Bin at(const Chromosome &chrom, std::uint32_t pos) const;
   [[nodiscard]] Bin at(std::string_view chrom_name, std::uint32_t pos) const;
   [[nodiscard]] Bin at(std::uint32_t chrom_id, std::uint32_t pos) const;
+  [[nodiscard]] Bin at_hint(std::uint64_t bin_id, const Chromosome &chrom) const;
 
   // Map genomic coords to bin_id
   [[nodiscard]] std::pair<std::uint64_t, std::uint64_t> map_to_bin_ids(

--- a/src/include/coolerpp/pixel_selector.hpp
+++ b/src/include/coolerpp/pixel_selector.hpp
@@ -59,10 +59,11 @@ class PixelSelector {
   [[nodiscard]] const PixelCoordinates &coord2() const noexcept;
 
   class iterator {
+    using BinIDT = std::uint64_t;
     friend PixelSelector<N, CHUNK_SIZE>;
 
-    Dataset::iterator<std::uint64_t, CHUNK_SIZE> _bin1_id_it{};
-    Dataset::iterator<std::uint64_t, CHUNK_SIZE> _bin2_id_it{};
+    Dataset::iterator<BinIDT, CHUNK_SIZE> _bin1_id_it{};
+    Dataset::iterator<BinIDT, CHUNK_SIZE> _bin2_id_it{};
     Dataset::iterator<N, CHUNK_SIZE> _count_it{};
 
     mutable Pixel<N> _value{};
@@ -82,15 +83,6 @@ class PixelSelector {
 
     static auto at_end(std::shared_ptr<const Index> index, const Dataset &pixels_bin1_id,
                        const Dataset &pixels_bin2_id, const Dataset &pixels_count) -> iterator;
-
-    static auto at_end(std::shared_ptr<const Index> index, const Dataset &pixels_bin1_id,
-                       const Dataset &pixels_bin2_id, const Dataset &pixels_count,
-                       PixelCoordinates coord1, PixelCoordinates coord2) -> iterator;
-
-    static auto at_end(std::shared_ptr<const Index> index, const Dataset &pixels_bin1_id,
-                       const Dataset &pixels_bin2_id, const Dataset &pixels_count,
-                       std::shared_ptr<const PixelCoordinates> coord1,
-                       std::shared_ptr<const PixelCoordinates> coord2) -> iterator;
 
    public:
     using difference_type = std::ptrdiff_t;
@@ -123,15 +115,17 @@ class PixelSelector {
     void jump_to_col(std::uint64_t bin_id);
     void jump(std::uint64_t bin1_id, std::uint64_t bin2_id);
     void jump_to_next_overlap();
-    [[nodiscard]] bool discard() const;
+
     [[nodiscard]] std::size_t h5_offset() const noexcept;
     void jump_at_end();
     void refresh();
-    [[nodiscard]] constexpr bool pixel_is_outdated() const noexcept;
     void read_pixel() const;
-    constexpr void assert_within_bound() const noexcept;
+
+    [[nodiscard]] constexpr bool overlaps_coord1() const noexcept;
+    [[nodiscard]] constexpr bool overlaps_coord2() const noexcept;
+
+    [[nodiscard]] bool discard() const;
     constexpr bool is_at_end() const noexcept;
-    constexpr bool is_past_end() const noexcept;
   };
 };
 

--- a/src/include/coolerpp/pixel_selector.hpp
+++ b/src/include/coolerpp/pixel_selector.hpp
@@ -69,8 +69,8 @@ class PixelSelector {
     mutable Pixel<N> _value{};
     std::shared_ptr<const Index> _index{};
 
-    std::shared_ptr<const PixelCoordinates> _coord1{};
-    std::shared_ptr<const PixelCoordinates> _coord2{};
+    PixelCoordinates _coord1{};
+    PixelCoordinates _coord2{};
 
     std::uint64_t _h5_end_offset{};
 

--- a/src/pixel_selector_impl.hpp
+++ b/src/pixel_selector_impl.hpp
@@ -85,13 +85,8 @@ inline auto PixelSelector<N, CHUNK_SIZE>::cbegin() const -> iterator {
 
 template <typename N, std::size_t CHUNK_SIZE>
 inline auto PixelSelector<N, CHUNK_SIZE>::cend() const -> iterator {
-  if (!this->_coord1) {
-    assert(!this->_coord2);
-    return iterator::at_end(this->_index, *this->_pixels_bin1_id, *this->_pixels_bin2_id,
-                            *this->_pixels_count);
-  }
   return iterator::at_end(this->_index, *this->_pixels_bin1_id, *this->_pixels_bin2_id,
-                          *this->_pixels_count, this->_coord1, this->_coord2);
+                          *this->_pixels_count);
 }
 
 template <typename N, std::size_t CHUNK_SIZE>
@@ -111,8 +106,8 @@ inline PixelSelector<N, CHUNK_SIZE>::iterator::iterator(std::shared_ptr<const In
                                                         const Dataset &pixels_bin1_id,
                                                         const Dataset &pixels_bin2_id,
                                                         const Dataset &pixels_count)
-    : _bin1_id_it(pixels_bin1_id.begin<std::uint64_t, CHUNK_SIZE>()),
-      _bin2_id_it(pixels_bin2_id.begin<std::uint64_t, CHUNK_SIZE>()),
+    : _bin1_id_it(pixels_bin1_id.begin<BinIDT, CHUNK_SIZE>()),
+      _bin2_id_it(pixels_bin2_id.begin<BinIDT, CHUNK_SIZE>()),
       _count_it(pixels_count.begin<N, CHUNK_SIZE>()),
       _index(std::move(index)),
       _coord1(nullptr),
@@ -128,7 +123,8 @@ inline PixelSelector<N, CHUNK_SIZE>::iterator::iterator(std::shared_ptr<const In
                                                         PixelCoordinates coord2)
     : _index(std::move(index)),
       _coord1(std::make_shared<PixelCoordinates>(std::move(coord1))),
-      _coord2(std::make_shared<PixelCoordinates>(std::move(coord2))) {
+      _coord2(std::make_shared<PixelCoordinates>(std::move(coord2))),
+      _h5_end_offset(pixels_bin2_id.size()) {
   assert(_coord1);
   assert(_coord2);
   assert(_coord1->bin1.id() <= _coord1->bin2.id());
@@ -136,20 +132,9 @@ inline PixelSelector<N, CHUNK_SIZE>::iterator::iterator(std::shared_ptr<const In
 
   // Set iterator to the first row overlapping the query (i.e. the first bin overlapping coord1)
   auto offset = _index->get_offset_by_bin_id(_coord1->bin1.id());
-  _bin1_id_it = pixels_bin1_id.make_iterator_at_offset<std::uint64_t, CHUNK_SIZE>(offset);
-  _bin2_id_it = pixels_bin2_id.make_iterator_at_offset<std::uint64_t, CHUNK_SIZE>(offset);
+  _bin1_id_it = pixels_bin1_id.make_iterator_at_offset<BinIDT, CHUNK_SIZE>(offset);
+  _bin2_id_it = pixels_bin2_id.make_iterator_at_offset<BinIDT, CHUNK_SIZE>(offset);
   _count_it = pixels_count.make_iterator_at_offset<N, CHUNK_SIZE>(offset);
-
-  // Init last iterator. at_end will return an iterator pointing to the pixel past the last pixel
-  // overlapping the query
-  auto it = iterator::at_end(this->_index, pixels_bin1_id, pixels_bin2_id, pixels_count, _coord1,
-                             _coord2);
-  _h5_end_offset = it._h5_end_offset;
-  assert(!this->is_past_end());
-
-  if (_bin2_id_it.h5_offset() == pixels_bin2_id.size()) {
-    return;
-  }
 
   // Now that last it is set, we can call jump_to_col() to seek to the first pixel actually
   // overlapping the query. Calling jump_to_next_overlap() is required to deal with rows that are
@@ -157,6 +142,10 @@ inline PixelSelector<N, CHUNK_SIZE>::iterator::iterator(std::shared_ptr<const In
   this->jump_to_col(_coord2->bin1.id());
   if (this->discard()) {
     this->jump_to_next_overlap();
+  }
+
+  if (this->is_at_end()) {
+    *this = at_end(std::move(this->_index), pixels_bin1_id, pixels_bin2_id, pixels_count);
   }
 }
 
@@ -168,104 +157,10 @@ inline auto PixelSelector<N, CHUNK_SIZE>::iterator::at_end(std::shared_ptr<const
     -> iterator {
   iterator it{};
   it._index = std::move(index);
-  it._bin1_id_it = pixels_bin1_id.end<std::uint64_t, CHUNK_SIZE>();
-  it._bin2_id_it = pixels_bin2_id.end<std::uint64_t, CHUNK_SIZE>();
-  it._h5_end_offset = it._bin2_id_it.h5_offset();
+  it._bin1_id_it = pixels_bin1_id.end<BinIDT, CHUNK_SIZE>();
+  it._bin2_id_it = pixels_bin2_id.end<BinIDT, CHUNK_SIZE>();
   it._count_it = pixels_count.end<N, CHUNK_SIZE>();
-
-  return it;
-}
-
-template <typename N, std::size_t CHUNK_SIZE>
-inline auto PixelSelector<N, CHUNK_SIZE>::iterator::at_end(std::shared_ptr<const Index> index,
-                                                           const Dataset &pixels_bin1_id,
-                                                           const Dataset &pixels_bin2_id,
-                                                           const Dataset &pixels_count,
-                                                           PixelCoordinates coord1,
-                                                           PixelCoordinates coord2) -> iterator {
-  std::shared_ptr<const PixelCoordinates> coord1_ =
-      !!coord1 ? std::make_shared<const PixelCoordinates>(std::move(coord1)) : nullptr;
-  std::shared_ptr<const PixelCoordinates> coord2_ =
-      !!coord2 ? std::make_shared<const PixelCoordinates>(std::move(coord2)) : nullptr;
-
-  return PixelSelector<N, CHUNK_SIZE>::iterator::at_end(std::move(index), pixels_bin1_id,
-                                                        pixels_bin2_id, pixels_count,
-                                                        std::move(coord1_), std::move(coord2_));
-}
-
-template <typename N, std::size_t CHUNK_SIZE>
-inline auto PixelSelector<N, CHUNK_SIZE>::iterator::at_end(
-    std::shared_ptr<const Index> index, const Dataset &pixels_bin1_id,
-    const Dataset &pixels_bin2_id, const Dataset &pixels_count,
-    std::shared_ptr<const PixelCoordinates> coord1, std::shared_ptr<const PixelCoordinates> coord2)
-    -> iterator {
-  if (!coord1 && !coord2) {
-    return at_end(std::move(index), pixels_bin1_id, pixels_bin2_id, pixels_count);
-  }
-  assert(!!coord1);
-  assert(!!coord2);
-
-  assert(coord1->bin2.id() <= coord2->bin2.id());
-
-  iterator it{};
-
-  it._index = std::move(index);
-  it._coord1 = std::move(coord1);
-  it._coord2 = std::move(coord2);
-
-  // Get the bin id for the last row overlapping the query
-  auto bin1_id = it._coord1->bin2.id();
-
-  if (bin1_id != 0) {
-    // Efficiently deal with the possiblity that a cooler file does not have any
-    // interactions overlapping or upstream of the queried region
-    const auto offset = it._index->get_offset_by_bin_id(bin1_id);
-    if (offset == 0) {
-      it._bin1_id_it = pixels_bin1_id.begin<std::uint64_t, CHUNK_SIZE>();
-      it._bin2_id_it = pixels_bin2_id.begin<std::uint64_t, CHUNK_SIZE>();
-      it._count_it = pixels_count.begin<N, CHUNK_SIZE>();
-      it._h5_end_offset = it._bin2_id_it.h5_offset();
-      return it;
-    }
-  }
-
-  do {
-    // Get the offset to the last row overlapping the query
-    const auto offset = it._index->get_offset_by_bin_id(bin1_id);
-    it._bin1_id_it = pixels_bin1_id.make_iterator_at_offset<std::uint64_t, CHUNK_SIZE>(offset);
-    it._bin2_id_it = pixels_bin2_id.make_iterator_at_offset<std::uint64_t, CHUNK_SIZE>(offset);
-    // Even though we do not yet know where the last iterator actually is, the jump methods expect
-    // _h5_end_offset to be set to something.
-    it._h5_end_offset = pixels_bin2_id.size();
-
-    it._count_it = pixels_count.make_iterator_at_offset<N, CHUNK_SIZE>(offset);
-
-    if (offset == pixels_bin2_id.size()) {
-      return it;
-    }
-
-    // Jump to the first column overlapping the query
-    it.jump_to_col(it._coord2->bin1.id());
-
-    // If discard() returns true, it means that the row corresponding to bin1_id does not contain
-    // any pixel overlapping the query, so we keep looking backwards
-  } while (bin1_id-- > it._coord1->bin1.id() && it.discard());
-
-  // Now that we know the row pointed by it contains at least one pixel overlapping the query, jump
-  // to the last column overlapping the query
-  it.jump_to_col(it._coord2->bin2.id());
-
-  // IMPORTANT! Do not try to set _bin2_id_last before calling it.discard(), otherwise discard will
-  // always return true!
-  if (it.discard()) {
-    // Pixel pointed to by it does not overlap the query (i.e. matrix has 0 interactions for the
-    // current row and col bin2_id()
-    it._h5_end_offset = it._bin2_id_it.h5_offset();
-  } else {
-    // it points to the last pixel overlapping the query, so increment last_it and it
-    it._h5_end_offset = it._bin2_id_it.h5_offset() + 1;
-    std::ignore = ++it;
-  }
+  it._h5_end_offset = pixels_bin2_id.size();
 
   return it;
 }
@@ -311,10 +206,8 @@ constexpr bool PixelSelector<N, CHUNK_SIZE>::iterator::operator>=(
 template <typename N, std::size_t CHUNK_SIZE>
 inline auto PixelSelector<N, CHUNK_SIZE>::iterator::operator*() const -> const_reference {
   assert(this->_index);
-  assert_within_bound();
-  if (this->pixel_is_outdated()) {
-    this->read_pixel();
-  }
+  assert(!this->is_at_end());
+  this->read_pixel();
   return this->_value;
 }
 
@@ -325,7 +218,7 @@ inline auto PixelSelector<N, CHUNK_SIZE>::iterator::operator->() const -> const_
 
 template <typename N, std::size_t CHUNK_SIZE>
 inline auto PixelSelector<N, CHUNK_SIZE>::iterator::operator++() -> iterator & {
-  assert_within_bound();
+  assert(!this->is_at_end());
   std::ignore = ++this->_bin1_id_it;
   std::ignore = ++this->_bin2_id_it;
   std::ignore = ++this->_count_it;
@@ -333,9 +226,6 @@ inline auto PixelSelector<N, CHUNK_SIZE>::iterator::operator++() -> iterator & {
   if (this->discard()) {
     this->jump_to_next_overlap();
   }
-
-  // signal _value is outdated
-  this->_value.count = 0;
 
   return *this;
 }
@@ -355,17 +245,15 @@ inline void PixelSelector<N, CHUNK_SIZE>::iterator::jump_to_row(std::uint64_t bi
   assert(this->_index);
   assert(bin_id <= this->_index->bins().size());
 
-  if (this->is_at_end() || this->is_past_end()) {
+  if (this->is_at_end()) {
     return;
   }
 
-  const auto end_offset = this->_h5_end_offset;
   const auto row_offset = this->_index->get_offset_by_bin_id(bin_id);
   const auto current_offset = this->h5_offset();
 
   assert(row_offset >= current_offset);
-  assert(end_offset >= current_offset);
-  const auto offset = (std::min)(end_offset, row_offset) - current_offset;
+  const auto offset = row_offset - current_offset;
 
   this->_bin1_id_it += offset;
   this->_bin2_id_it += offset;
@@ -377,7 +265,7 @@ inline void PixelSelector<N, CHUNK_SIZE>::iterator::jump_to_col(std::uint64_t bi
   assert(this->_index);
   assert(bin_id <= this->_index->bins().size());
 
-  if (this->is_at_end() || this->is_past_end()) {
+  if (this->is_at_end()) {
     return;
   }
 
@@ -387,7 +275,6 @@ inline void PixelSelector<N, CHUNK_SIZE>::iterator::jump_to_col(std::uint64_t bi
   const auto current_offset = conditional_static_cast<std::uint64_t>(this->h5_offset());
   const auto current_row_offset = this->_index->get_offset_by_bin_id(current_row);
   const auto next_row_offset = this->_index->get_offset_by_bin_id(next_row);
-  const auto end_offset = this->_h5_end_offset;
 
   if (current_offset == next_row_offset) {
     return;  // Row is empty
@@ -395,7 +282,7 @@ inline void PixelSelector<N, CHUNK_SIZE>::iterator::jump_to_col(std::uint64_t bi
 
   assert(next_row_offset != 0);
   const auto row_start_offset = (std::min)(current_offset, current_row_offset);
-  const auto row_end_offset = (std::min)(end_offset, next_row_offset - 1);
+  const auto row_end_offset = next_row_offset - 1;
 
   if (row_start_offset == row_end_offset) {
     return;  // Row is empty
@@ -411,7 +298,6 @@ inline void PixelSelector<N, CHUNK_SIZE>::iterator::jump_to_col(std::uint64_t bi
   this->_count_it += offset;
 
   assert(*this->_bin1_id_it == current_row);
-  assert(!this->is_past_end());
 }
 
 template <typename N, std::size_t CHUNK_SIZE>
@@ -427,11 +313,12 @@ inline void PixelSelector<N, CHUNK_SIZE>::iterator::jump(std::uint64_t bin1_id,
 
 template <typename N, std::size_t CHUNK_SIZE>
 inline void PixelSelector<N, CHUNK_SIZE>::iterator::jump_to_next_overlap() {
+  assert(this->discard());
   assert(this->_coord1);
   assert(this->_coord2);
-  while (this->discard()) {
+  do {
     // We're at/past end: return immediately
-    if (this->is_at_end() || this->is_past_end()) {
+    if (this->is_at_end()) {
       this->jump_at_end();
       return;
     }
@@ -451,36 +338,19 @@ inline void PixelSelector<N, CHUNK_SIZE>::iterator::jump_to_next_overlap() {
 
     // There's no more data to be read, as we're past the last column overlapping the query,
     // and the next row does not overlap the query
-    if (this->is_at_end() || this->is_past_end() || next_row > this->_coord1->bin2.id()) {
+    if (this->is_at_end() || next_row > this->_coord1->bin2.id()) {
       // assert(col > this->_coord2->bin2.id());  // This is not always true for trans queries
       this->jump_at_end();
       return;
     }
 
     this->jump(next_row, next_col);
-  }
-}
-
-template <typename N, std::size_t CHUNK_SIZE>
-inline bool PixelSelector<N, CHUNK_SIZE>::iterator::discard() const {
-  if (!this->_coord1) {
-    // Iterator is traversing the entire matrix:
-    // no pixel should be discarded
-    assert(!this->_coord2);
-    return false;
-  }
+  } while (this->discard());
 
   if (this->is_at_end()) {
-    return false;
+    this->jump_at_end();
+    return;
   }
-
-  const auto overlaps_range1 = *this->_bin1_id_it >= this->_coord1->bin1.id() &&
-                               *this->_bin1_id_it <= this->_coord1->bin2.id();
-
-  const auto overlaps_range2 = *this->_bin2_id_it >= this->_coord2->bin1.id() &&
-                               *this->_bin2_id_it <= this->_coord2->bin2.id();
-
-  return !overlaps_range1 || !overlaps_range2;
 }
 
 template <typename N, std::size_t CHUNK_SIZE>
@@ -493,24 +363,10 @@ inline std::size_t PixelSelector<N, CHUNK_SIZE>::iterator::h5_offset() const noe
 
 template <typename N, std::size_t CHUNK_SIZE>
 inline void PixelSelector<N, CHUNK_SIZE>::iterator::jump_at_end() {
-  if (this->is_at_end()) {
-    return;
+  if (this->_h5_end_offset != this->_bin2_id_it.h5_offset()) {
+    *this = at_end(std::move(this->_index), this->_bin1_id_it.dataset(),
+                   this->_bin2_id_it.dataset(), this->_count_it.dataset());
   }
-
-  // Deal with iterators upstream of last
-  if (!this->is_past_end()) {
-    const auto offset = this->_h5_end_offset - this->_bin2_id_it.h5_offset();
-    this->_bin1_id_it += offset;
-    this->_bin2_id_it += offset;
-    this->_count_it += offset;
-    return;
-  }
-
-  // Deal with iterators downstream of last
-  const auto offset = this->_bin2_id_it.h5_offset() - this->_h5_end_offset;
-  this->_bin1_id_it -= offset;
-  this->_bin2_id_it -= offset;
-  this->_count_it -= offset;
 }
 
 template <typename N, std::size_t CHUNK_SIZE>
@@ -521,21 +377,13 @@ inline void PixelSelector<N, CHUNK_SIZE>::iterator::refresh() {
   const auto &bin2_dset = this->_bin2_id_it.dataset();
   const auto &count_dset = this->_count_it.dataset();
 
-  this->_bin1_id_it =
-      bin1_dset.template make_iterator_at_offset<std::uint64_t, CHUNK_SIZE>(h5_offset);
-  this->_bin2_id_it =
-      bin2_dset.template make_iterator_at_offset<std::uint64_t, CHUNK_SIZE>(h5_offset);
+  this->_bin1_id_it = bin1_dset.template make_iterator_at_offset<BinIDT, CHUNK_SIZE>(h5_offset);
+  this->_bin2_id_it = bin2_dset.template make_iterator_at_offset<BinIDT, CHUNK_SIZE>(h5_offset);
   this->_count_it = count_dset.template make_iterator_at_offset<N, CHUNK_SIZE>(h5_offset);
 }
 
 template <typename N, std::size_t CHUNK_SIZE>
-constexpr bool PixelSelector<N, CHUNK_SIZE>::iterator::pixel_is_outdated() const noexcept {
-  return this->_value.count == 0;
-}
-
-template <typename N, std::size_t CHUNK_SIZE>
 inline void PixelSelector<N, CHUNK_SIZE>::iterator::read_pixel() const {
-  assert(this->pixel_is_outdated());
   if (!!this->_coord1) {
     this->_value.coords = PixelCoordinates{
         this->_index->bins().at_hint(*this->_bin1_id_it, this->_coord1->bin1.chrom()),
@@ -549,17 +397,32 @@ inline void PixelSelector<N, CHUNK_SIZE>::iterator::read_pixel() const {
 }
 
 template <typename N, std::size_t CHUNK_SIZE>
-constexpr void PixelSelector<N, CHUNK_SIZE>::iterator::assert_within_bound() const noexcept {
-  assert(this->_bin2_id_it.h5_offset() < this->_h5_end_offset);
+constexpr bool PixelSelector<N, CHUNK_SIZE>::iterator::overlaps_coord1() const noexcept {
+  return !this->_coord1 || (*this->_bin1_id_it >= this->_coord1->bin1.id() &&
+                            *this->_bin1_id_it <= this->_coord1->bin2.id());
+}
+
+template <typename N, std::size_t CHUNK_SIZE>
+constexpr bool PixelSelector<N, CHUNK_SIZE>::iterator::overlaps_coord2() const noexcept {
+  return !this->_coord2 || (*this->_bin2_id_it >= this->_coord2->bin1.id() &&
+                            *this->_bin2_id_it <= this->_coord2->bin2.id());
+}
+
+template <typename N, std::size_t CHUNK_SIZE>
+inline bool PixelSelector<N, CHUNK_SIZE>::iterator::discard() const {
+  if (this->is_at_end()) {
+    return false;
+  }
+
+  return !this->overlaps_coord1() || !this->overlaps_coord2();
 }
 
 template <typename N, std::size_t CHUNK_SIZE>
 constexpr bool PixelSelector<N, CHUNK_SIZE>::iterator::is_at_end() const noexcept {
-  return this->_bin2_id_it.h5_offset() == this->_h5_end_offset;
+  if (this->_h5_end_offset == this->_bin2_id_it.h5_offset()) {
+    return true;
+  }
+  return !this->overlaps_coord1() && !this->overlaps_coord2();
 }
 
-template <typename N, std::size_t CHUNK_SIZE>
-constexpr bool PixelSelector<N, CHUNK_SIZE>::iterator::is_past_end() const noexcept {
-  return this->_bin2_id_it.h5_offset() > this->_h5_end_offset;
-}
 }  // namespace coolerpp

--- a/src/pixel_selector_impl.hpp
+++ b/src/pixel_selector_impl.hpp
@@ -536,8 +536,15 @@ constexpr bool PixelSelector<N, CHUNK_SIZE>::iterator::pixel_is_outdated() const
 template <typename N, std::size_t CHUNK_SIZE>
 inline void PixelSelector<N, CHUNK_SIZE>::iterator::read_pixel() const {
   assert(this->pixel_is_outdated());
-  this->_value.coords = PixelCoordinates{this->_index->bins().at(*this->_bin1_id_it),
-                                         this->_index->bins().at(*this->_bin2_id_it)};
+  if (!!this->_coord1) {
+    this->_value.coords = PixelCoordinates{
+        this->_index->bins().at_hint(*this->_bin1_id_it, this->_coord1->bin1.chrom()),
+        this->_index->bins().at_hint(*this->_bin2_id_it, this->_coord2->bin1.chrom())};
+
+  } else {
+    this->_value.coords = PixelCoordinates{this->_index->bins().at(*this->_bin1_id_it),
+                                           this->_index->bins().at(*this->_bin2_id_it)};
+  }
   this->_value.count = *this->_count_it;
 }
 

--- a/src/pixel_selector_impl.hpp
+++ b/src/pixel_selector_impl.hpp
@@ -221,6 +221,11 @@ inline auto PixelSelector<N, CHUNK_SIZE>::iterator::operator++() -> iterator & {
   std::ignore = ++this->_bin2_id_it;
   std::ignore = ++this->_count_it;
 
+  if (this->is_at_end()) {
+    this->jump_at_end();
+    return *this;
+  }
+
   if (this->discard()) {
     this->jump_to_next_overlap();
   }

--- a/test/units/balancing_test.cpp
+++ b/test/units/balancing_test.cpp
@@ -98,10 +98,6 @@ TEST_CASE("Coolerpp: Balancer", "[cooler][short]") {
         const auto sel = Balancer(
             clr.fetch<std::int32_t>("chr1", 5'000'000, 10'000'000, "chr2", 5'000'000, 10'000'000),
             clr.read_weights("weight"));
-        for (const auto& p : clr.fetch<std::int32_t>("chr1", 5'000'000, 10'000'000, "chr2",
-                                                     5'000'000, 10'000'000)) {
-          fmt::print(FMT_STRING("{}\n"), p);
-        }
         constexpr std::array<double, 4> expected{0.001782, 0.002756, 0.002047, 0.004749};
         balancer_test_helper(sel, expected);
       }

--- a/test/units/bin_table_test.cpp
+++ b/test/units/bin_table_test.cpp
@@ -239,7 +239,7 @@ TEST_CASE("BinTable", "[bin-table][short]") {
 
       auto it = table.begin() + 5;
       for (std::size_t i = 0; i < expected.size() - 5; ++i) {
-        CHECK(*(it + i) == expected[i + 5]);
+        CHECK(*(it + i) == expected[i + 5]);  // NOLINT
       }
     }
 
@@ -248,9 +248,9 @@ TEST_CASE("BinTable", "[bin-table][short]") {
       CHECK(*(table.end() - 5) == *(expected.end() - 5));
 
       auto it1 = table.end();
-      auto it2 = expected.end();
+      auto it2 = expected.end();  // NOLINT
       for (std::size_t i = 1; i < expected.size(); ++i) {
-        CHECK(*(it1 - i) == *(it2 - i));
+        CHECK(*(it1 - i) == *(it2 - i));  // NOLINT
       }
     }
   }

--- a/test/units/bin_table_test.cpp
+++ b/test/units/bin_table_test.cpp
@@ -122,19 +122,6 @@ TEST_CASE("BinTable", "[bin-table][short]") {
   }
 
   SECTION("at") {
-    const BinTable expected{{Chromosome{1, "chr2", 25017}}, bin_size};
-
-    CHECK(table.subset(Chromosome{1, "chr2", 25017}) == expected);
-    CHECK(table.subset("chr2") == expected);
-    CHECK(table.subset(1) == expected);
-    CHECK(table.subset("chr1") != expected);
-
-    CHECK_THROWS_AS(table.subset(Chromosome{4, "chr5", 1}), std::out_of_range);
-    CHECK_THROWS_AS(table.subset("a"), std::out_of_range);
-    CHECK_THROWS_AS(table.subset(10), std::out_of_range);
-  }
-
-  SECTION("bin id to coord") {
     const auto& chr1 = table.chromosomes().at("chr1");
     const auto& chr2 = table.chromosomes().at("chr2");
 
@@ -157,6 +144,36 @@ TEST_CASE("BinTable", "[bin-table][short]") {
     CHECK_THROWS_AS(table.map_to_bin_id("chr1", 99999), std::out_of_range);
     CHECK_THROWS_AS(table.map_to_bin_id(chr2, 99999), std::out_of_range);
     CHECK_THROWS_AS(table.map_to_bin_id(1, 99999), std::out_of_range);
+  }
+
+  SECTION("subset") {
+    const BinTable expected{{Chromosome{1, "chr2", 25017}}, bin_size};
+
+    CHECK(table.subset(Chromosome{1, "chr2", 25017}) == expected);
+    CHECK(table.subset("chr2") == expected);
+    CHECK(table.subset(1) == expected);
+    CHECK(table.subset("chr1") != expected);
+
+    CHECK_THROWS_AS(table.subset(Chromosome{4, "chr5", 1}), std::out_of_range);
+    CHECK_THROWS_AS(table.subset("a"), std::out_of_range);
+    CHECK_THROWS_AS(table.subset(10), std::out_of_range);
+  }
+
+  SECTION("find overlap") {
+    const auto& chrom = *table.chromosomes().begin();
+
+    auto its = table.find_overlap({chrom, 10'000, 10'001});
+    CHECK(std::distance(its.first, its.second) == 1);
+
+    its = table.find_overlap({chrom, 0, bin_size - 1});
+    CHECK(std::distance(its.first, its.second) == 1);
+
+    its = table.find_overlap({chrom, 10'000, 20'000});
+    CHECK(std::distance(its.first, its.second) == 2);
+
+    its = table.find_overlap({chrom, 0, chrom.size()});
+    const auto table1 = table.subset(chrom);
+    CHECK(std::distance(its.first, its.second) == std::distance(table1.begin(), table1.end()));
   }
 
   SECTION("iterators") {
@@ -212,6 +229,28 @@ TEST_CASE("BinTable", "[bin-table][short]") {
       }
 
       CHECK(first_bin == last_bin);
+    }
+
+    SECTION("operator+") {
+      CHECK(table.begin() + 0 == table.begin());
+      CHECK(*(table.begin() + 5) == expected[5]);
+
+      auto it = table.begin() + 5;
+      for (std::size_t i = 0; i < expected.size() - 5; ++i) {
+        CHECK(*(it + i) == expected[i + 5]);
+      }
+    }
+
+    SECTION("operator-") {
+      CHECK(table.begin() - 0 == table.begin());
+      CHECK(*(table.end() - 5) == *(expected.end() - 5));
+
+      auto it1 = table.end();
+      auto it2 = expected.end();
+      for (std::size_t i = 1; i < expected.size(); ++i) {
+        fmt::print(FMT_STRING("i={}; {:bed} == {:bed}\n"), i, *(it1 - i), *(it2 - i));
+        CHECK(*(it1 - i) == *(it2 - i));
+      }
     }
   }
 

--- a/test/units/bin_table_test.cpp
+++ b/test/units/bin_table_test.cpp
@@ -154,7 +154,9 @@ TEST_CASE("BinTable", "[bin-table][short]") {
     CHECK(table.subset(1) == expected);
     CHECK(table.subset("chr1") != expected);
 
-    CHECK_THROWS_AS(table.subset(Chromosome{4, "chr5", 1}), std::out_of_range);
+    if constexpr (ndebug_not_defined()) {
+      CHECK_THROWS_AS(table.subset(Chromosome{4, "chr5", 1}), std::out_of_range);
+    }
     CHECK_THROWS_AS(table.subset("a"), std::out_of_range);
     CHECK_THROWS_AS(table.subset(10), std::out_of_range);
   }
@@ -248,7 +250,6 @@ TEST_CASE("BinTable", "[bin-table][short]") {
       auto it1 = table.end();
       auto it2 = expected.end();
       for (std::size_t i = 1; i < expected.size(); ++i) {
-        fmt::print(FMT_STRING("i={}; {:bed} == {:bed}\n"), i, *(it1 - i), *(it2 - i));
         CHECK(*(it1 - i) == *(it2 - i));
       }
     }


### PR DESCRIPTION
- Make `BinTable::iterator` random access
- Optimize bin look up by providing a `BinTable::at_hint()` method to speed up lookups when chromosome is already known
- Simplify implementation of `PixelSelector<N>::iterator`. This gives a 20-30% performance on random queries at medium resolutions
- Store `PixelCoordinates` inline in `PixelSelector<N>` and its iterator. This gives a small performance improvement (2-3%)